### PR TITLE
Improve description of -v option

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ For example, the child-parent relationship between two nodes is not explicitly
 defined. Given a plain AST node, it is not possible to traverse the tree *up*.
 Given a path object however, the parent can be traversed to via `path.parent`.
 
-For more information about the path object API, please have a look at 
+For more information about the path object API, please have a look at
 [ast-types][].
 
 #### Builders
@@ -253,7 +253,7 @@ transform can be made more readable.
 There are two types of extensions: generic extensions and type-specific
 extensions. Generic extensions are applicable to all collections. As such, they
 typically don't access specific node data, but rather traverse the AST from the
-nodes in the collection.  
+nodes in the collection.
 Type-specific extensions work only on specific node types and are not callable
 on differently typed collections.
 

--- a/README.md
+++ b/README.md
@@ -251,11 +251,10 @@ into helper functions (which can be stored separately in other modules), a
 transform can be made more readable.
 
 There are two types of extensions: generic extensions and type-specific
-extensions. Generic extensions are applicable to all collections. As such, they
-typically don't access specific node data, but rather traverse the AST from the
-nodes in the collection.
-Type-specific extensions work only on specific node types and are not callable
-on differently typed collections.
+extensions. **Generic extensions** are applicable to all collections. As such,
+they typically don't access specific node data, but rather traverse the AST from
+the nodes in the collection. **Type-specific** extensions work only on specific
+node types and are not callable on differently typed collections.
 
 #### Examples
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ path     Files to transform
 Options:
    -t FILE, --transform FILE   Path to the transform file  [./transform.js]
    -c, --cpus                  (all by default) Determines the number of processes started.
-   -v, --verbosity             Repeate to show more information about the transform process  [0]
+   -v, --verbosity             Show more information about the transform process  [0]
    -d, --dry                   Dry run (no changes are made to files)
    -p, --print                 Print output, useful for development
 ```

--- a/bin/jscodeshift.sh
+++ b/bin/jscodeshift.sh
@@ -38,7 +38,7 @@ var opts = require('nomnom')
       abbr: 'v',
       choices: [0, 1, 2],
       default: 0,
-      help: 'Repeate to show more information about the transform process'
+      help: 'Show more information about the transform process'
     },
     dry: {
       abbr: 'd',


### PR DESCRIPTION
I found the description for this option to be confusing, partly because
I don't think "repeate" is actually a word, and partly because if it
was a typo for "repeat", it hardly makes sense to me here. In any case,
these words seem unnecessary and can probably just be removed entirely.

I also remove the two occurrences of trailing whitespace in the readme.