### PR TITLE
Change implementation of collections

### DIFF
--- a/src/collections/JSXElement.js
+++ b/src/collections/JSXElement.js
@@ -10,6 +10,7 @@
 
 "use strict";
 
+var _ = require('lodash');
 var Collection = require('../Collection');
 var NodeCollection = require('./Node');
 
@@ -186,6 +187,6 @@ function register() {
   Collection.registerMethods(traversalMethods, JSXElement);
 }
 
-exports.register = register;
+exports.register = _.once(register);
 exports.filters = filterMethods;
 exports.mappings = mappingMethods;

--- a/src/collections/Node.js
+++ b/src/collections/Node.js
@@ -10,6 +10,7 @@
 
 "use strict";
 
+var _ = require('lodash');
 var Collection = require('../Collection');
 
 var assert = require('assert');
@@ -187,4 +188,4 @@ function register() {
   Collection.setDefaultCollectionType(Node);
 }
 
-exports.register = register;
+exports.register = _.once(register);

--- a/src/collections/VariableDeclarator.js
+++ b/src/collections/VariableDeclarator.js
@@ -9,6 +9,8 @@
  */
 
 "use strict";
+
+var _ = require('lodash');
 var Collection = require('../Collection');
 var NodeCollection = require('./Node');
 var matchNode = require('../matchNode');
@@ -107,5 +109,5 @@ function register() {
   Collection.registerMethods(transformMethods, VariableDeclarator);
 }
 
-exports.register = register;
+exports.register = _.once(register);
 exports.filters = filterMethods;

--- a/src/collections/__tests__/JSXElement-test.js
+++ b/src/collections/__tests__/JSXElement-test.js
@@ -46,7 +46,7 @@ describe('JSXCollection API', function() {
   describe('Traversal', function() {
     it('returns a non empty JSXCollection', function() {
       var jsx = Collection.fromNodes(nodes).find(types.JSXElement);
-      expect(jsx.constructor.name).toContain('JSXElementCollection');
+      expect(jsx.getTypes()).toContain('JSXElement');
       expect(jsx.size()).toBeGreaterThan(0);
     });
 
@@ -68,7 +68,7 @@ describe('JSXCollection API', function() {
         .findJSXElements('FooBar')
         .childNodes();
       expect(children.size()).toBe(5);
-      expect(children.constructor.name).toContain('ExpressionCollection');
+      expect(children.getTypes()).toContain('Expression');
     });
 
     it('returns the child JSXElements of an JSXElement', function() {
@@ -78,7 +78,7 @@ describe('JSXCollection API', function() {
         .childElements();
 
       expect(children.size()).toBe(2);
-      expect(children.constructor.name).toContain('JSXElementCollection');
+      expect(children.getTypes()).toContain('JSXElement');
     });
 
     it('returns a properly typed collection even if empty', function() {
@@ -88,7 +88,7 @@ describe('JSXCollection API', function() {
         .childElements();
 
       expect(children.size()).toBe(0);
-      expect(children.constructor.name).toContain('JSXElementCollection');
+      expect(children.getTypes()).toContain('JSXElement');
     });
   });
 

--- a/src/collections/__tests__/VariableDeclarator-test.js
+++ b/src/collections/__tests__/VariableDeclarator-test.js
@@ -53,8 +53,7 @@ describe('VariableDeclarators', function() {
 
     it('finds all variable declarators', function() {
       var declarators = Collection.fromNodes(nodes).findVariableDeclarators();
-      expect(declarators.constructor.name)
-        .toContain('VariableDeclaratorCollection');
+      expect(declarators.getTypes()).toContain('VariableDeclarator');
       expect(declarators.size()).toBe(5);
     });
 


### PR DESCRIPTION
Note: This is not a breaking change. It only changes how collections are
represented internally and solves a couple of issues with the current
implementation.

#### How typed collections currently work

ast-types defines a type hierarchy. For example, a "BlockStatement" has this
hierarchy:

    BlockStatement <- Statement <- Node <- Printable

I.e. a "BlockStatement" is also a "Statement", a "Node", etc.

jscodeshift uses this hierarchy to model collection classes. Every collection
class inherits from its supertype/parent collection class. For example,
"BlockStatementCollection" inherits from a "StatementCollection",
etc.

Whenever `registerMethods(methods, type)` is called, classes for "type"
and all its supertypes are created, if they don't exist yet, and are extended
with "methods". This works (obviously) but has some disadvantages. The biggest
are:

**Unable to account for multiple parents**

Some types actually have multiple parent types. For example, a
"FunctionExpression" is both a "Function" and an "Expression". The
following currently fails because "ExpressionCollection" is not in the
inheritance chain of "FunctionExpressionCollection":

```js
jscodeshift.registerMethods({
  expressionMethod: function() {}
}, jscodeshift.Expression);

jscodeshift('(function foo() {})')
  .find(jscodeshift.FunctionExpression)
  .expressionMethod();
```

This will throw the unhelpful error message: "undefined is not a
function".

Which brings me to the next issue:

**Unhelpful error messages**

If you are getting a collection of a different type (A) than you expect (say B),
and trying to call a method specific only to B, then you will get the
error message "undefined is not a function". At this point, it's not
clear whether the issue is just a typo, different naming of the method
or if you get a differently typed collection.

#### How typed collections work after this change

Instead of dynamically creating classes which inherit from each other,
there will only be a single `Collection` class. Each collection instance
has an internal `_types` property which holds a list of types the
collection supports (i.e. all nodes in the collection are of these types).

Registered methods are just added to the prototype of the `Collection` class.
If such a method is called, we will first check whether the type it was
registered for is in the internal list of types. If it is not, we can
provide a helpful error, containing which type the method was registered
for and which types the current collection is made of.

Since everything is flat now, there is also no problem with multiple
parents anymore. The above example would just work.

This implementation currently does not allow to register a method with
the same name for different types. I think this is fine, because having
a method that does different things depending on the type of the
collection can be confusing. However, if it turns our that this is too
restrictive we can consider alternatives.

---

After this change we should also think about restructuring the source
code to better reflect the new structure.