### PR TITLE
Rename --verbosity option to --verbose

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ path     Files to transform
 Options:
    -t FILE, --transform FILE   Path to the transform file  [./transform.js]
    -c, --cpus                  (all by default) Determines the number of processes started.
-   -v, --verbosity             Show more information about the transform process  [0]
+   -v, --verbose               Show more information about the transform process  [0]
    -d, --dry                   Dry run (no changes are made to files)
    -p, --print                 Print output, useful for development
 ```

--- a/bin/jscodeshift.sh
+++ b/bin/jscodeshift.sh
@@ -34,7 +34,7 @@ var opts = require('nomnom')
       abbr: 'c',
       help: '(all by default) Determines the number of processes started.'
     },
-    verbosity: {
+    verbose: {
       abbr: 'v',
       choices: [0, 1, 2],
       default: 0,

--- a/src/Runner.js
+++ b/src/Runner.js
@@ -15,17 +15,17 @@ var clc = require('cli-color');
 var cpus = require('os').cpus().length - 1;
 var fs = require('fs');
 
-function ok(msg, verbosity) {
-  verbosity >= 2 && console.log(clc.white.bgGreen(' OKK '), msg);
+function ok(msg, verbose) {
+  verbose >= 2 && console.log(clc.white.bgGreen(' OKK '), msg);
 }
-function nochange(msg, verbosity) {
-  verbosity >= 1 && console.log(clc.white.bgYellow(' NOC '), msg);
+function nochange(msg, verbose) {
+  verbose >= 1 && console.log(clc.white.bgYellow(' NOC '), msg);
 }
-function skip(msg, verbosity) {
-  verbosity >= 1 && console.log(clc.white.bgYellow(' SKIP'), msg);
+function skip(msg, verbose) {
+  verbose >= 1 && console.log(clc.white.bgYellow(' SKIP'), msg);
 }
-function error(msg, verbosity) {
-  verbosity >= 0 && console.log(clc.white.bgRedBright(' ERR '), msg);
+function error(msg, verbose) {
+  verbose >= 0 && console.log(clc.white.bgRedBright(' ERR '), msg);
 }
 
 function showFileStats(fileStats) {
@@ -112,7 +112,7 @@ function run(transformFile, files, options) {
     switch (message.action) {
       case 'status':
         fileCounters[message.status] += 1;
-        log[message.status](message.msg, options.verbosity);
+        log[message.status](message.msg, options.verbose);
         break;
       case 'update':
         if (!statsCounter[message.name]) {


### PR DESCRIPTION
For consistency with most other command-line tools out there. Note that
this is a breaking change, but I think we can probably get away without
adding a separate option and keeping `--verbosity` around as a duplicate
(which would clutter the usage output).