### PR TITLE
Update `"use strict"` hints to follow style guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ outlined on that page and do not file a public issue.
 * Commas last,
 * 2 spaces for indentation (no tabs)
 * Prefer `'` over `"`
-* `"use strict";`
+* `'use strict';`
 * 80 character line length
 * "Attractive"
 

--- a/bin/__tests__/jscodeshift-test.js
+++ b/bin/__tests__/jscodeshift-test.js
@@ -10,7 +10,7 @@
 
 /*global jest, describe, pit, expect*/
 
-"use strict";
+'use strict';
 
 jest.autoMockOff();
 

--- a/bin/jscodeshift.sh
+++ b/bin/jscodeshift.sh
@@ -9,7 +9,7 @@
  *
  */
 
-"use strict";
+'use strict';
 
 var Runner = require('../dist/Runner.js');
 

--- a/scripts/test-preprocess.js
+++ b/scripts/test-preprocess.js
@@ -8,7 +8,7 @@
  *
  */
 
-"use strict";
+'use strict';
 
 var reactTools = require('react-tools');
 

--- a/src/Collection.js
+++ b/src/Collection.js
@@ -8,7 +8,7 @@
  *
  */
 
-"use strict";
+'use strict';
 
 var assert = require('assert');
 var recast = require('recast');

--- a/src/Runner.js
+++ b/src/Runner.js
@@ -8,7 +8,7 @@
  *
  */
 
-"use strict";
+'use strict';
 
 var child_process = require('child_process');
 var clc = require('cli-color');

--- a/src/Worker.js
+++ b/src/Worker.js
@@ -8,7 +8,7 @@
  *
  */
 
-"use strict";
+'use strict';
 
 var async = require('async');
 var fs = require('fs');

--- a/src/__tests__/Collection-test.js
+++ b/src/__tests__/Collection-test.js
@@ -8,7 +8,7 @@
  *
  */
 
-"use strict";
+'use strict';
 
 jest.autoMockOff();
 

--- a/src/__tests__/core-test.js
+++ b/src/__tests__/core-test.js
@@ -8,7 +8,7 @@
  *
  */
 
-"use strict";
+'use strict';
 jest.autoMockOff();
 var core = require('../core');
 var Collection = require('../Collection');

--- a/src/collections/JSXElement.js
+++ b/src/collections/JSXElement.js
@@ -8,7 +8,7 @@
  *
  */
 
-"use strict";
+'use strict';
 
 var _ = require('lodash');
 var Collection = require('../Collection');

--- a/src/collections/Node.js
+++ b/src/collections/Node.js
@@ -8,7 +8,7 @@
  *
  */
 
-"use strict";
+'use strict';
 
 var _ = require('lodash');
 var Collection = require('../Collection');

--- a/src/collections/VariableDeclarator.js
+++ b/src/collections/VariableDeclarator.js
@@ -8,7 +8,7 @@
  *
  */
 
-"use strict";
+'use strict';
 
 var _ = require('lodash');
 var Collection = require('../Collection');

--- a/src/collections/__tests__/JSXElement-test.js
+++ b/src/collections/__tests__/JSXElement-test.js
@@ -8,7 +8,7 @@
  *
  */
 
-"use strict";
+'use strict';
 
 jest.autoMockOff();
 

--- a/src/collections/__tests__/Node-test.js
+++ b/src/collections/__tests__/Node-test.js
@@ -8,7 +8,7 @@
  *
  */
 
-"use strict";
+'use strict';
 
 jest.autoMockOff();
 

--- a/src/collections/__tests__/VariableDeclarator-test.js
+++ b/src/collections/__tests__/VariableDeclarator-test.js
@@ -8,7 +8,7 @@
  *
  */
 
-"use strict";
+'use strict';
 
 jest.autoMockOff();
 

--- a/src/core.js
+++ b/src/core.js
@@ -8,7 +8,7 @@
  *
  */
 
-"use strict";
+'use strict';
 var Collection = require('./Collection');
 
 var collections = require('./collections');


### PR DESCRIPTION
Our `CONTRIBUTING.md` documentation tells us to prefer single quotes
over doubles, but on the very next line we tell people to do `"use
strict"`.

This commit makes us bow to our single-quote overlords consistently
everywhere.