### PR TITLE
[RFC] Remove node

### DIFF
--- a/src/collections/Node.js
+++ b/src/collections/Node.js
@@ -165,6 +165,10 @@ var mutationMethods = {
         (typeof insert === 'function') ? insert.call(path, path, i) : insert;
       path.insertAfter(...toArray(newNodes));
     });
+  },
+
+  remove: function() {
+    this.forEach(path => path.prune());
   }
 
 };

--- a/src/collections/__tests__/Node-test.js
+++ b/src/collections/__tests__/Node-test.js
@@ -347,5 +347,36 @@ describe('Collection API', function() {
         expect(ast.expressions[3]).toBe(x);
       });
     });
+
+    describe('removes', function() {
+      it('removes a node if it is part of the body of a statement', function() {
+        var x = b.expressionStatement(b.identifier('x'));
+        var y = b.expressionStatement(b.identifier('y'));
+        var ast = b.program([x, y]);
+
+        var S = Collection.fromNodes([ast])
+          .find(types.Identifier, {name: 'x'})
+          .remove();
+
+        expect(ast.body.length).toBe(1);
+        expect(ast.body[0]).toBe(y);
+      });
+
+      it('removes a node if it is a function param', function() {
+        var x = b.identifier('x');
+        var y = b.identifier('y');
+        var ast = b.arrowFunctionExpression(
+          [x, b.identifier('z')],
+          y
+        );
+
+        var S = Collection.fromNodes([ast])
+          .find(types.Identifier, {name: 'z'})
+          .remove();
+        expect(ast.params.length).toBe(1);
+        expect(ast.params[0]).toBe(x);
+        expect(ast.body).toBe(y);
+      });
+    });
   });
 });


### PR DESCRIPTION
Removing a node is hard. This is an initial implementation of a function `remove` that can remove a node if it is part of any AST field that is an array. I probably missed some but this should be a good start.

I'm not entirely sure what I should do in the case that the parent becomes empty. In some cases you'd want the parent to remove itself (empty block in a function?) but sometimes you probably don't (removing all params from a function, remove all items from an object expression). I think this is best left to the developer, although I'm wondering if we can provide hints. Should the `remove` method return something like `All expressions from a "SequenceExpression" were removed. You can now consider removing the SequenceExpression`?