### PR TITLE
Pre-process transform files with babel. Fixes #5

### DIFF
--- a/bin/jscodeshift.sh
+++ b/bin/jscodeshift.sh
@@ -49,6 +49,11 @@ var opts = require('nomnom')
       abbr: 'p',
       flag: true,
       help: 'Print output, useful for development'
+    },
+    babel: {
+      flag: true,
+      default: true,
+      help: 'Do not apply babel for transform files'
     }
   })
   .parse();

--- a/src/Runner.js
+++ b/src/Runner.js
@@ -127,7 +127,7 @@ function run(transformFile, files, options) {
   file_chunks.forEach(function(files) {
     var child = child_process.fork(
       require.resolve('./Worker'),
-      [transformFile]
+      [transformFile, options.babel ? 'babel' : 'no-babel']
     );
     child.send({files: files, options: options});
     child.on('message', onMessage);

--- a/src/Worker.js
+++ b/src/Worker.js
@@ -10,6 +10,10 @@
 
 'use strict';
 
+if (process.argv[3] === 'babel') {
+  require('babel/register')();
+}
+
 var async = require('async');
 var fs = require('fs');
 


### PR DESCRIPTION
This uses babel's require hook. The downside is that every worker will transform every file, but workers are limited to number of CPUs so I think the overhead of doing this a few times isn't a big deal. Also added an option `babel` to disable this behavior.

Other solutions we've explored:
* Transform the script in the Runner and create a temp file. This breaks `require` calls in the transform script because the temp file would be relative
* Put the temp file into the same folder as the transform file. This means that `require` works but other files won't be transformed.