### PR TITLE
Add ability to pass one or many directories to jscodeshift. Fixes #21

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ jscodeshift --help
 
 Usage: jscodeshift <path>... [options]
 
-path     Files to transform
+path     Files or directory to transform
 
 Options:
    -t FILE, --transform FILE   Path to the transform file  [./transform.js]
@@ -36,6 +36,8 @@ Options:
    -v, --verbose               Show more information about the transform process  [0]
    -d, --dry                   Dry run (no changes are made to files)
    -p, --print                 Print output, useful for development
+   --babel                     Do not apply babel for transform files  [true]
+   --extensions                File extensions the transform file should be applied to  [js]
 ```
 
 This passes the source of all passed through the transform module specified
@@ -133,7 +135,7 @@ You can collect even more stats via the `stats` function as explained above.
 ### Example
 
 ```text
-$ jscodeshift -t myTransform.js src/**/*.js
+$ jscodeshift -t myTransform.js src
 Processing 10 files...
 Spawning 2 workers with 5 files each...
 All workers done.

--- a/bin/__tests__/jscodeshift-test.js
+++ b/bin/__tests__/jscodeshift-test.js
@@ -15,7 +15,7 @@
 jest.autoMockOff();
 
 // Increase default timeout (5000ms) for Travis
-jasmine.getEnv().defaultTimeoutInterval = 10000;
+jasmine.getEnv().defaultTimeoutInterval = 15000;
 
 var child_process = require('child_process');
 var fs = require('fs');
@@ -67,13 +67,13 @@ describe('jscodeshift CLI', () => {
     );
 
     return Promise.all([
-      run(['-t', transformA, sourceA, sourceB]).then(
+      run(['--no-extensions', '-t', transformA, sourceA, sourceB]).then(
         ([stdout, stderr]) => {
           expect(fs.readFileSync(sourceA).toString()).toBe('transforma');
           expect(fs.readFileSync(sourceB).toString()).toBe('transformb');
         }
       ),
-      run(['-t', transformB, sourceC]).then(
+      run(['--no-extensions', '-t', transformB, sourceC]).then(
         ([stdout, stderr]) => {
           expect(fs.readFileSync(sourceC).toString()).toBe(sourceC);
         }
@@ -101,7 +101,7 @@ describe('jscodeshift CLI', () => {
       '    typeof api.stats === "function"',
       '  );',
     ].join('\n'));
-    return run(['-t', transform, source]).then(
+    return run(['--no-extensions', '-t', transform, source]).then(
       ([stdout, stderr]) => {
         expect(fs.readFileSync(source).toString()).toBe('true');
       }
@@ -111,7 +111,7 @@ describe('jscodeshift CLI', () => {
   pit('passes options along to the transform', () => {
     var source = createTempFileWith('a');
     var transform = createTransformWith('return options.foo;');
-    return run(['-t', transform, '--foo=42', source]).then(
+    return run(['--no-extensions', '-t', transform, '--foo=42', source]).then(
       ([stdout, stderr]) => {
         expect(fs.readFileSync(source).toString()).toBe('42');
       }

--- a/bin/jscodeshift.sh
+++ b/bin/jscodeshift.sh
@@ -19,7 +19,7 @@ var opts = require('nomnom')
   .options({
     path: {
       position: 0,
-      help: 'Files to transform',
+      help: 'Files or directory to transform',
       list: true,
       metavar: 'FILE',
       required: true
@@ -54,6 +54,10 @@ var opts = require('nomnom')
       flag: true,
       default: true,
       help: 'Do not apply babel for transform files'
+    },
+    extensions: {
+      default: 'js',
+      help: 'File extensions the transform file should be applied to'
     }
   })
   .parse();

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-jest": "^5.3.0",
     "es6-promise": "^2.0.1",
     "jest-cli": "^0.4.0",
+    "node-dir": "0.1.8",
     "temp": "^0.8.1"
   },
   "jest": {


### PR DESCRIPTION
This allows us to use jscodeshift without find/xargs which should really help with the cli ergonomics. I've been fighting with this all the time and got really annoyed, so glad I finally got around to change the Runner.

This makes use of `node-dir` and uses Promises. I converted the Runner code to ES6, pretty sure there are some subjective code style choices but I tried to make the style more "functional" and use const where appropriate.