### PR TITLE
Add a newline to the end of a file by default.

### DIFF
--- a/bin/__tests__/jscodeshift-test.js
+++ b/bin/__tests__/jscodeshift-test.js
@@ -57,7 +57,7 @@ describe('jscodeshift CLI', () => {
 
   pit('calls the transform and file information', () => {
     var sourceA = createTempFileWith('a');
-    var sourceB = createTempFileWith('b');
+    var sourceB = createTempFileWith('b\n');
     var sourceC = createTempFileWith('c');
     var transformA = createTransformWith(
       'return "transform" + fileInfo.source;'
@@ -70,7 +70,7 @@ describe('jscodeshift CLI', () => {
       run(['--no-extensions', '-t', transformA, sourceA, sourceB]).then(
         ([stdout, stderr]) => {
           expect(fs.readFileSync(sourceA).toString()).toBe('transforma');
-          expect(fs.readFileSync(sourceB).toString()).toBe('transformb');
+          expect(fs.readFileSync(sourceB).toString()).toBe('transformb\n');
         }
       ),
       run(['--no-extensions', '-t', transformB, sourceC]).then(

--- a/src/Worker.js
+++ b/src/Worker.js
@@ -79,6 +79,9 @@ process.on('message', function(data) {
             console.log(out);
           }
           if (!options.dry) {
+            if (/\n$/.test(source) && !/\n$/.test(out)) {
+              out += '\n';
+            }
             fs.writeFile(file, out, function(err) {
               if (err) {
                 updateStatus('error', file, 'File writer error: ' + err);


### PR DESCRIPTION
Multiple people have asked me why in their diff the last line of every file was changed. I think this is a reasonable default and will allow me to get rid of the `+ '\n'` code in most of my transforms.