### PR TITLE
Fix printing

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,11 @@
+{
+  "parser": "babel-eslint",
+  "rules": {
+    "comma-dangle": 0,
+    "quotes": [2, "single", "avoid-escape"],
+    "strict": 0
+  },
+  "env": {
+    "node": true
+  }
+}

--- a/bin/__tests__/jscodeshift-test.js
+++ b/bin/__tests__/jscodeshift-test.js
@@ -8,14 +8,13 @@
  *
  */
 
-/*global jest, describe, pit, expect*/
-
-'use strict';
+/*global jest, jasmine, describe, pit, expect*/
+/*eslint camelcase: 0, no-unused-vars: 0*/
 
 jest.autoMockOff();
 
 // Increase default timeout (5000ms) for Travis
-jasmine.getEnv().defaultTimeoutInterval = 15000;
+jasmine.getEnv().defaultTimeoutInterval = 30000;
 
 var child_process = require('child_process');
 var fs = require('fs');
@@ -57,7 +56,7 @@ describe('jscodeshift CLI', () => {
 
   pit('calls the transform and file information', () => {
     var sourceA = createTempFileWith('a');
-    var sourceB = createTempFileWith('b');
+    var sourceB = createTempFileWith('b\n');
     var sourceC = createTempFileWith('c');
     var transformA = createTransformWith(
       'return "transform" + fileInfo.source;'
@@ -70,7 +69,7 @@ describe('jscodeshift CLI', () => {
       run(['--no-extensions', '-t', transformA, sourceA, sourceB]).then(
         ([stdout, stderr]) => {
           expect(fs.readFileSync(sourceA).toString()).toBe('transforma');
-          expect(fs.readFileSync(sourceB).toString()).toBe('transformb');
+          expect(fs.readFileSync(sourceB).toString()).toBe('transformb\n');
         }
       ),
       run(['--no-extensions', '-t', transformB, sourceC]).then(

--- a/src/__tests__/core-test.js
+++ b/src/__tests__/core-test.js
@@ -8,10 +8,10 @@
  *
  */
 
-'use strict';
+/*global jest, describe, it, expect*/
+
 jest.autoMockOff();
 var core = require('../core');
-var Collection = require('../Collection');
 var recast = require('recast');
 var b = recast.types.builders;
 var NodePath = recast.types.NodePath;
@@ -46,8 +46,13 @@ describe('core API', function() {
   });
 
   it('throws if it gets an invalid value', function() {
-    expect(_ => core(42)).toThrow();
-    expect(_ => core({})).toThrow();
+    expect(() => core(42)).toThrow();
+    expect(() => core({})).toThrow();
+  });
+
+  it('returns the source as is if nothing was modified', function () {
+    var source = '\nvar foo;\n';
+    expect(core(source).toSource()).toEqual(source);
   });
 
 });

--- a/src/core.js
+++ b/src/core.js
@@ -71,7 +71,7 @@ function fromAST(ast) {
 }
 
 function fromSource(source) {
-  return fromAST(recast.parse(source, {esprima: babel}).program);
+  return fromAST(recast.parse(source, {esprima: babel}));
 }
 
 /**


### PR DESCRIPTION
There have been multiple reports about the printed source missing trailing line breaks. The reason for the line break missing is that this information is contained in the `File` node, which is returned by
`recast.parse`.
However, because we build a node collection from the `Program` node instead of the `File` node, we are loosing this information.
Using the `File` node fixes the issue and doesn't seem to break any existing functionality.