### PR TITLE
Fix for "cpus" command line parameter

### DIFF
--- a/src/Runner.js
+++ b/src/Runner.js
@@ -74,7 +74,7 @@ function getAllFiles(paths) {
 }
 
 function run(transformFile, paths, options) {
-  const cpus = options.cpus ? Math.min(cpus, options.cpus) : availableCpus;
+  const cpus = options.cpus ? Math.min(availableCpus, options.cpus) : availableCpus;
   const extensions =
     options.extensions && options.extensions.split(',').map(ext => '.' + ext);
   const fileChunks = [];


### PR DESCRIPTION
There is no "cpus" variable at that point, which breaks the Math.min() expression and as a result, no workers are spawned if the -c option is used.

"availableCpus" seems to be the variable that was meant to be used and fixed the problem for me.