### PR TITLE
Collections: support negative indicies

### DIFF
--- a/src/Collection.js
+++ b/src/Collection.js
@@ -147,11 +147,22 @@ class Collection {
   /**
    * Returns a new collection containing only the element at position index.
    *
+   * In case of a negative index, the element is taken from the end:
+   *
+   *   .at(0)  - first element
+   *   .at(-1) - last element
+   *
    * @param {number} index
    * @return {Collection}
    */
   at(index) {
-    return fromPaths(this.__paths.slice(index, index+1), this);
+    return fromPaths(
+      this.__paths.slice(
+        index,
+        index === -1 ? undefined : index + 1
+      ),
+      this
+    );
   }
 
   /**

--- a/src/__tests__/Collection-test.js
+++ b/src/__tests__/Collection-test.js
@@ -190,5 +190,20 @@ describe('Collection API', function() {
         expect(mapped.paths()[0]).toBe(path);
       });
     });
+
+    describe('at', function() {
+      it('should work with positive indecies', function() {
+        var root = Collection.fromNodes(nodes);
+        expect(root.at(0).nodes()[0]).toEqual(nodes[0]);
+        expect(root.at(1).nodes()[0]).toEqual(nodes[1]);
+      });
+
+      it('should work with negative indecies', function() {
+        var root = Collection.fromNodes(nodes);
+        expect(root.at(-1).nodes()[0]).toEqual(nodes[nodes.length - 1]);
+        expect(root.at(-2).nodes()[0]).toEqual(nodes[nodes.length - 2]);
+      });
+    });
+
   });
 });


### PR DESCRIPTION
Adds support for negative indices to conveniently refer to needed nodes without saving them to local vars.