### PR TITLE
Remove check on registerMethods

### DIFF
--- a/src/Collection.js
+++ b/src/Collection.js
@@ -298,9 +298,6 @@ var CPt = Collection.prototype;
  */
 function registerMethods(methods, type) {
   for (var methodName in methods) {
-    if (CPt.hasOwnProperty(methodName)) {
-      throw Error(`A method with name "${methodName}" already exists.`);
-    }
     if (!type) {
       CPt[methodName] = methods[methodName];
     } else {


### PR DESCRIPTION
This check prevents using registerMethods with iterative development with things like test:watch, astexplorer.net, etc.

Maybe there's a better way to handle this, but I'm not sure the check provides much value period and it has caused me plenty of headaches.