### PR TITLE
Improvements to matchNode

### DIFF
--- a/src/__tests__/matchNode-test.js
+++ b/src/__tests__/matchNode-test.js
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/*global jest, describe, it, expect*/
+
+jest.autoMockOff();
+var matchNode = require('../matchNode');
+
+describe('matchNode', function() {
+  beforeEach(function() {
+    jest.addMatchers({
+      toMatchNode: function(needle) {
+        var haystack = this.actual;
+        return matchNode(haystack, needle);
+      }
+    });
+  })
+
+  it('matches null and undefined', function() {
+    expect(null).toMatchNode(null);
+    expect(null).not.toMatchNode(undefined);
+
+    expect(undefined).toMatchNode(undefined);
+    expect(undefined).not.toMatchNode(null);
+  });
+
+  it('matches scalars', function() {
+    expect('foo').toMatchNode('foo');
+    expect('foo').not.toMatchNode('bar');
+    expect('123').not.toMatchNode(123);
+
+    expect(123).toMatchNode(123);
+    expect(123).not.toMatchNode(456);
+    expect(123).not.toMatchNode('123');
+
+    expect(true).toMatchNode(true);
+    expect(true).not.toMatchNode(false);
+    expect(true).not.toMatchNode('true');
+  });
+
+  it('matches arrays', function() {
+    expect([1, 2, 3]).toMatchNode([1, 2, 3]);
+    expect([1, 2, 3]).not.toMatchNode([4, 5, 6]);
+
+    expect([[1, 2, 3], 'foo']).toMatchNode([[1, 2, 3], 'foo']);
+    expect([[1, 2, 3], 'foo']).not.toMatchNode([[456], 'foo']);
+    expect([[1, 2, 3], 'foo']).not.toMatchNode([[1, 2, 3], 'bar']);
+
+    expect([1, 2, 3, 4]).toMatchNode([1, 2, 3]);
+    expect([1, 2, 3]).not.toMatchNode([1, 2, 3, 4]);
+  });
+
+  it('matches objects', function() {
+    expect({}).toMatchNode({});
+    expect({name: 'foo'}).toMatchNode({name: 'foo'});
+    expect({name: 'foo'}).not.toMatchNode({name: 'bar'});
+
+    expect({name: 'foo', value: {name: 'bar'}})
+      .toMatchNode({name: 'foo', value: {name: 'bar'}});
+    expect({name: 'foo', value: {name: 'bar'}})
+      .not.toMatchNode({name: 'foo', value: {name: 'baz'}});
+
+    expect({name: 'foo', value: 'bar'}).toMatchNode({name: 'foo'});
+    expect({name: 'foo'}).not.toMatchNode({name: 'foo', value: 'bar'});
+
+    expect(Object.create({name: 'foo'})).not.toMatchNode({name: 'foo'});
+    expect({}).toMatchNode(Object.create({name: 'foo'}));
+  });
+
+  it('matches with a function', function() {
+    var haystack = {name: 'foo'};
+    var needle = jest.genMockFunction();
+
+    needle.mockReturnValue(true);
+    expect(haystack).toMatchNode(needle);
+    expect(needle).toBeCalledWith(haystack);
+
+    needle.mockReturnValue(false);
+    expect(haystack).not.toMatchNode(needle);
+  });
+
+  it('matches nested value with a function', function() {
+    var haystack = {name: 'foo', value: 'bar'};
+    var needle = {
+      name: jest.genMockFunction(),
+      value: jest.genMockFunction(),
+    };
+
+    needle.name.mockReturnValue(true);
+    needle.value.mockReturnValue(true);
+    expect(haystack).toMatchNode(needle);
+    expect(needle.name).toBeCalledWith(haystack.name);
+    expect(needle.value).toBeCalledWith(haystack.value);
+
+    needle.name.mockReturnValue(false);
+    needle.value.mockReturnValue(true);
+    expect(haystack).not.toMatchNode(needle);
+
+    needle.name.mockReturnValue(true);
+    needle.value.mockReturnValue(false);
+    expect(haystack).not.toMatchNode(needle);
+  });
+});

--- a/src/matchNode.js
+++ b/src/matchNode.js
@@ -17,10 +17,13 @@ var hasOwn =
  * Checks whether needle is a strict subset of haystack.
  *
  * @param {Object} haystack The object to test
- * @param {Object} needle The properties to look for in test
+ * @param {Object|Function} needle The properties to look for in test
  * @return {bool}
  */
 function matchNode(haystack, needle) {
+  if (typeof needle === 'function') {
+    return needle(haystack);
+  }
   var props = Object.keys(needle);
   return props.every(function(prop) {
     if (!hasOwn(haystack, prop)) {

--- a/src/matchNode.js
+++ b/src/matchNode.js
@@ -30,8 +30,9 @@ function matchNode(haystack, needle) {
       return false;
     }
     if (haystack[prop] &&
-      typeof haystack[prop] === 'object' &&
-      typeof needle[prop] === 'object') {
+        needle[prop] &&
+        typeof haystack[prop] === 'object' &&
+        typeof needle[prop] === 'object') {
       return matchNode(haystack[prop], needle[prop]);
     }
     return haystack[prop] === needle[prop];

--- a/src/matchNode.js
+++ b/src/matchNode.js
@@ -16,27 +16,27 @@ var hasOwn =
 /**
  * Checks whether needle is a strict subset of haystack.
  *
- * @param {Object} haystack The object to test
- * @param {Object|Function} needle The properties to look for in test
+ * @param {*} haystack Value to test.
+ * @param {*} needle Test function or value to look for in `haystack`.
  * @return {bool}
  */
 function matchNode(haystack, needle) {
   if (typeof needle === 'function') {
     return needle(haystack);
   }
-  var props = Object.keys(needle);
-  return props.every(function(prop) {
-    if (!hasOwn(haystack, prop)) {
-      return false;
-    }
-    if (haystack[prop] &&
-        needle[prop] &&
-        typeof haystack[prop] === 'object' &&
-        typeof needle[prop] === 'object') {
-      return matchNode(haystack[prop], needle[prop]);
-    }
-    return haystack[prop] === needle[prop];
-  });
+  if (isNode(needle) && isNode(haystack)) {
+    return Object.keys(needle).every(function(property) {
+      return (
+        hasOwn(haystack, property) &&
+        matchNode(haystack[property], needle[property])
+      );
+    });
+  }
+  return haystack === needle;
+}
+
+function isNode(value) {
+  return typeof value === 'object' && value;
 }
 
 module.exports = matchNode;


### PR DESCRIPTION
Makes a couple improvements to `matchNodes`:

- Allow `path.find(j.Identifier, node => WHITELIST.hasOwnProperty(node.name))`.
- Fix fatal in `path.find(j.Identifier, {loc: null})`;

Also, added unit tests.