### PR TITLE
runner promise to be fullfilled with file counters

### DIFF
--- a/src/Runner.js
+++ b/src/Runner.js
@@ -154,7 +154,7 @@ function run(transformFile, paths, options) {
           endTime[0],
           (endTime[1]/1000000).toFixed(0)
         );
-        resolve();
+        return fileCounters;
       })
     );
 }

--- a/src/Runner.js
+++ b/src/Runner.js
@@ -144,7 +144,7 @@ function run(transformFile, paths, options) {
       });
     })
     .then(pendingWorkers =>
-      Promise.all(pendingWorkers).then(resolve => {
+      Promise.all(pendingWorkers).then(() => {
         const endTime = process.hrtime(startTime);
         console.log('All workers done.');
         showFileStats(fileCounters);


### PR DESCRIPTION
```js
Runner.run(
          transformer,
          files,
          opts
).then(function (result) {
          // this promise was always throwing, and result was not reacheable
})
```