### PR TITLE
Add '--run-in-band' option to run in the current process

### DIFF
--- a/bin/jscodeshift.sh
+++ b/bin/jscodeshift.sh
@@ -58,6 +58,12 @@ var opts = require('nomnom')
     extensions: {
       default: 'js',
       help: 'File extensions the transform file should be applied to'
+    },
+    runInBand: {
+      flag: true,
+      default: false,
+      full: 'run-in-band',
+      help: 'Run serially in the current process'
     }
   })
   .parse();


### PR DESCRIPTION
Like jest's `--run-in-band` so you can use `--debug/-brk` without hating life. If the `if (module.parent) {` block is too gross, then I'm open to suggestions. cc: @fkling @cpojer 