### PR TITLE
Fix `Collection.closest`

### DIFF
--- a/src/collections/Node.js
+++ b/src/collections/Node.js
@@ -19,30 +19,6 @@ var recast = require('recast');
 var Node = recast.types.namedTypes.Node;
 var types = recast.types.namedTypes;
 
-const findParent = (path, type, filter) => {
-  var parent = path.parent;
-  if (!parent) {
-    // Return null if we've reached the upper bound of
-    // the AST
-    return null;
-  } else if (
-    // return the node if we haven't specified a filter
-    // and the type check returns true.
-    parent && 
-    type.check(parent.value) && !filter) {
-    return parent;
-  } else if(
-    // return the node if both type check and filter
-    // return true
-    parent && type.check(parent.value) &&
-    filter && matchNode(parent.value, filter)
-  ) {
-    return parent;
-  } else {
-    return findParent(parent, type, filter);
-  }
-};
-
 var traversalMethods = {
 
   /**
@@ -98,7 +74,17 @@ var traversalMethods = {
    */
   closest: function(type, filter) {
     return this.map(function(path) {
-      return findParent(path, type, filter)
+      var parent = path.parent;
+      while (
+        parent &&
+        !(
+          type.check(parent.value) &&
+          (!filter || matchNode(parent.value, filter))
+        )
+      ) {
+        parent = parent.parent;
+      }
+      return parent || null;
     });
   },
 

--- a/src/collections/Node.js
+++ b/src/collections/Node.js
@@ -22,12 +22,18 @@ var types = recast.types.namedTypes;
 const findParent = (path, type, filter) => {
   var parent = path.parent;
   if (!parent) {
+    // Return null if we've reached the upper bound of
+    // the AST
     return null;
   } else if (
+    // return the node if we haven't specified a filter
+    // and the type check returns true.
     parent && 
     type.check(parent.value) && !filter) {
     return parent;
   } else if(
+    // return the node if both type check and filter
+    // return true
     parent && type.check(parent.value) &&
     filter && matchNode(parent.value, filter)
   ) {

--- a/src/collections/Node.js
+++ b/src/collections/Node.js
@@ -19,6 +19,24 @@ var recast = require('recast');
 var Node = recast.types.namedTypes.Node;
 var types = recast.types.namedTypes;
 
+const findParent = (path, type, filter) => {
+  var parent = path.parent;
+  if (!parent) {
+    return null;
+  } else if (
+    parent && 
+    type.check(parent.value) && !filter) {
+    return parent;
+  } else if(
+    parent && type.check(parent.value) &&
+    filter && matchNode(parent.value, filter)
+  ) {
+    return parent;
+  } else {
+    return findParent(parent, type, filter);
+  }
+};
+
 var traversalMethods = {
 
   /**
@@ -74,15 +92,7 @@ var traversalMethods = {
    */
   closest: function(type, filter) {
     return this.map(function(path) {
-      var parent = path.parent;
-      while (
-        parent &&
-        !type.check(parent.value) &&
-        !(filter && matchNode(parent.value, filter))
-      ) {
-        parent = parent.parent;
-      }
-      return parent || null;
+      return findParent(path, type, filter)
     });
   },
 

--- a/src/collections/__tests__/Node-test.js
+++ b/src/collections/__tests__/Node-test.js
@@ -130,18 +130,9 @@ describe('Collection API', function() {
     });
 
     describe('closest', function() {
-      it('finds closest node (up the tree) of the given type', function() {
-        var functionDeclaration = ast.body[1];
-        var decl = Collection.fromNodes([ast])
-          .find(types.Identifier)
-          .closest(types.FunctionDeclaration);
-
-        expect(decl.size()).toBe(1);
-        expect(decl.nodes()[0]).toBe(functionDeclaration);
-      });
-
-      it('allows to filter nodes by pattern', function() {
-        var decl = b.functionDeclaration(
+      var decl;
+      beforeEach(()=> {
+        decl = b.functionDeclaration(
           b.identifier('foo'),
           [],
           b.blockStatement([
@@ -156,6 +147,19 @@ describe('Collection API', function() {
             ),
           ])
         );
+      });
+
+      it('finds closest node (up the tree) of the given type', function() {
+        var functionDeclaration = ast.body[1];
+        decl = Collection.fromNodes([ast])
+          .find(types.Identifier)
+          .closest(types.FunctionDeclaration);
+
+        expect(decl.size()).toBe(1);
+        expect(decl.nodes()[0]).toBe(functionDeclaration);
+      });
+
+      it('allows to filter nodes by pattern', function() {
         var literals = Collection.fromNodes([decl])
           .find(types.Literal);
         expect(literals.get(0).node.value).toBe(3);
@@ -164,6 +168,28 @@ describe('Collection API', function() {
           {id: {name: 'foo'}}
         );
         expect(closest.get(0).node.id.name).toBe('foo');
+      });
+
+      it('allows to filter nodes with a filter function', function() {
+        var literals = Collection.fromNodes([decl])
+          .find(types.Literal);
+        expect(literals.get(0).node.value).toBe(3);
+        var closest = literals.closest(
+          types.FunctionDeclaration,
+          (node) => node.id && node.id.name === 'foo'
+        );
+        expect(closest.get(0).node.id.name).toBe('foo');
+      });
+
+      it('fails when filter evaluates as false', function() {
+        var literals = Collection.fromNodes([decl])
+          .find(types.Literal);
+        expect(literals.get(0).node.value).toBe(3);
+        var closest = literals.closest(
+          types.FunctionDeclaration,
+          (node) => node.id && node.id.name === 'blue'
+        );
+        expect(closest.nodes().length).toBe(0);
       });
     });
 

--- a/src/collections/__tests__/Node-test.js
+++ b/src/collections/__tests__/Node-test.js
@@ -146,7 +146,7 @@ describe('Collection API', function() {
           [],
           b.blockStatement([
             b.functionDeclaration(
-              b.identifier('foo'),
+              b.identifier('bar'),
               [],
               b.blockStatement([
                 b.returnStatement(


### PR DESCRIPTION
At the moment `Collection.closest` doesn't actually work with filters. If `type.check(parent.value)` in the while [loop on line 80](https://github.com/facebook/jscodeshift/blob/master/src/collections/Node.js#L80) returns `true` it will stop the while loop, skipping the last expression, which tests if the filter condition applies.

This pr fixes this and refactors the while loop into a recursive function which is imo more readable.

I also added some specs to prove that closest is working correctly.