### PR TITLE
Disable external Babel configuration

### DIFF
--- a/src/Worker.js
+++ b/src/Worker.js
@@ -40,7 +40,8 @@ if (module.parent) {
 
 function setup(tr, babel) {
   if (babel === 'babel') {
-    require('babel-core/register')();
+    // FIXME: use { babelrc: false } after migration to Babel 6
+    require('babel-core/register')({ breakConfig: true });
   }
   transform = require(tr);
 }


### PR DESCRIPTION
Hi!

This PR prevents jscodeshift's Babel from picking up external Babel configuration.
See [this](https://github.com/facebook/jscodeshift/issues/84) issue for more information.