### PR TITLE
Remote transform initial pass

### DIFF
--- a/bin/jscodeshift.sh
+++ b/bin/jscodeshift.sh
@@ -76,7 +76,7 @@ var opts = require('nomnom')
   .parse();
 
 Runner.run(
-  path.resolve(opts.transform),
+  /^https?/.test(opts.transform) ? opts.transform : path.resolve(opts.transform), 
   opts.path,
   opts
 );

--- a/src/Runner.js
+++ b/src/Runner.js
@@ -16,6 +16,7 @@ const child_process = require('child_process');
 const clc = require('cli-color');
 const fs = require('fs');
 const path = require('path');
+const http = require('http');
 const https = require('https');
 const temp = require('temp');
 
@@ -124,17 +125,10 @@ function run(transformFile, paths, options) {
   const startTime = process.hrtime();
 
   if (/^http/.test(transformFile)) {
-    if (transformFile.indexOf('https') !== 0) {
-      console.log(
-        clc.whiteBright.bgRed('ERROR') + ' Remote transforms only support https. %s',
-        transformFile
-     );
-      return;
-    }
-
     usedRemoteScript = true;
     return new Promise((resolve, reject) => {
-      https.get(transformFile, (res) => {
+      // call the correct `http` or `https` implementation
+      (transformFile.indexOf('https') !== 0 ?  http : https).get(transformFile, (res) => {
         let contents = '';
         res
           .on('data', (d) => {


### PR DESCRIPTION
An initial pass at including remote support for the transform flag.
```sh
jscodeshift -t https://raw.githubusercontent.com/reactjs/react-codemod/master/transforms/react-to-react-dom.js .
```

One constraint is the remote transform must be entirely self-contained.

- :white_check_mark: https://raw.githubusercontent.com/reactjs/react-codemod/raw/master/transforms/react-to-react-dom.js
- :x: https://raw.githubusercontent.com/reactjs/react-codemod/raw/master/transforms/create-element-to-jsx.js

Closes #94.