### PR TITLE
Fix processes count and chunk size for run-in-band mode

### DIFF
--- a/src/Runner.js
+++ b/src/Runner.js
@@ -139,8 +139,10 @@ function run(transformFile, paths, options) {
         return;
       }
 
-      const processes = Math.min(numFiles, cpus);
-      const chunkSize = Math.min(Math.ceil(numFiles / processes), CHUNK_SIZE);
+      const processes = options.runInBand ? 1 : Math.min(numFiles, cpus);
+      const chunkSize = processes > 1 ?
+        Math.min(Math.ceil(numFiles / processes), CHUNK_SIZE) :
+        numFiles;
 
       let index = 0;
       // return the next chunk of work for a free worker


### PR DESCRIPTION
The worker was being called more than once when in run-in-band mode.