### PR TITLE
Fix encoding errors in logging messages

### DIFF
--- a/src/Runner.js
+++ b/src/Runner.js
@@ -25,16 +25,16 @@ const CHUNK_SIZE = 50;
 
 const log = {
   ok(msg, verbose) {
-    verbose >= 2 && process.stdout.write(clc.white.bgGreen(' OKK '), msg);
+    verbose >= 2 && process.stdout.write(clc.white.bgGreen(' OKK ') + msg);
   },
   nochange(msg, verbose) {
-    verbose >= 1 && process.stdout.write(clc.white.bgYellow(' NOC '), msg);
+    verbose >= 1 && process.stdout.write(clc.white.bgYellow(' NOC ') + msg);
   },
   skip(msg, verbose) {
-    verbose >= 1 && process.stdout.write(clc.white.bgYellow(' SKIP'), msg);
+    verbose >= 1 && process.stdout.write(clc.white.bgYellow(' SKIP ') + msg);
   },
   error(msg, verbose) {
-    verbose >= 0 && process.stdout.write(clc.white.bgRedBright(' ERR '), msg);
+    verbose >= 0 && process.stdout.write(clc.white.bgRedBright(' ERR ') + msg);
   },
 };
 


### PR DESCRIPTION
The [`write` method on Stream][write] takes the second argument to be an encoding. This is certainly not what's needed in the log messages.

If you run `jscodeshift -v 2` on a file, you can get `TypeError` exceptions.

[write]: https://nodejs.org/api/stream.html#stream_writable_write_chunk_encoding_callback