### PR TITLE
Fix process disconnection

### DIFF
--- a/src/Worker.js
+++ b/src/Worker.js
@@ -32,7 +32,7 @@ if (module.parent) {
     return emitter;
   };
 } else {
-  finish = () => { process.disconnect(); };
+  finish = () => { setImmediate(process.disconnect) };
   notify = (data) => { process.send(data); };
   process.on('message', (data) => { run(data); });
   setup(process.argv[2], process.argv[3]);

--- a/src/Worker.js
+++ b/src/Worker.js
@@ -32,7 +32,7 @@ if (module.parent) {
     return emitter;
   };
 } else {
-  finish = () => { setImmediate(process.disconnect) };
+  finish = () => setImmediate(() => process.disconnect());
   notify = (data) => { process.send(data); };
   process.on('message', (data) => { run(data); });
   setup(process.argv[2], process.argv[3]);


### PR DESCRIPTION
I can consistently reproduce a problem with `jscodeshift` where all the transformations are applied correctly, but the process doesn't exit--it just hangs. It may be related to the problem that is described by @ForbesLindesay in #87.

This is solved by forcing child workers to execute `process.disconnect` at the beginning of their next event loop interation instead of during the event loop interation in which they are processing their final message. The relevant documentation is in the [Node docs][disconnect-docs].

> The 'disconnect' event will be emitted when there are no messages in the process of being received. This will most often be triggered immediately after calling child.disconnect().

Unfortunately, the files I've used to produce this behavior are part of a proprietary piece of software. I'll try to reproduce the bug on something I can publish. But until then, I should note that I'm able to do this with `-c 1` (one worker), with fewer than 100 files.

I'm running Node 5.6.0 on OS X 10.11.3.

[disconnect-docs]: https://nodejs.org/api/child_process.html#child_process_child_disconnect