### PR TITLE
Add simple utility for unit testing jscodeshift transform

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 /src/
+/sample/
 .gitignore
 .jshintrc
 .module-cache

--- a/README.md
+++ b/README.md
@@ -292,6 +292,40 @@ This can be done by passing config options to [recast].
 
 More on config options [here](https://github.com/benjamn/recast/blob/52a7ec3eaaa37e78436841ed8afc948033a86252/lib/options.js#L61)
 
+### Unit Testing
+
+jscodeshift comes with a simple utility to allow easy unit testing with [Jest](https://facebook.github.io/jest/), without having to write a lot of boilerplate code. This utility makes some assumptions in order to reduce the amount of configuration required:
+
+ - The test is located in a subdirectory under the directory the transform itself is located in (eg. `__tests__`)
+ - Test fixtures are located in a `__testfixtures__` directory
+
+This results in a directory structure like this:
+```
+/MyTransform.js
+/__tests__/MyTransform-test.js
+/__testfixtures__/MyTransform.input.js
+/__testfixtures__/MyTransform.output.js
+```
+
+To define a test, use `defineTest` from the `testUtils` module:
+
+```js
+jest.autoMockOff();
+const defineTest = require('jscodeshift/dist/testUtils').defineTest;
+defineTest(__dirname, 'MyTransform');
+```
+
+An alternate fixture filename can be provided as the fourth argument to `defineTest`. This also means that multiple test fixtures can be provided:
+```js
+defineTest(__dirname, 'MyTransform', null, 'FirstFixture');
+defineTest(__dirname, 'MyTransform', null, 'SecondFixture');
+```
+This will run two tests: One for `__testfixtures__/FirstFixture.input.js` and one for `__testfixtures__/SecondFixture.input.js`
+
+
+A simple example is bundled in the [sample directory](sample).
+
+
 ### Example Codemods
 
 - [react-codemod](https://github.com/reactjs/react-codemod) - React codemod scripts to update React APIs.

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "preprocessCachingDisabled": true,
     "testPathDirs": [
       "src",
-      "bin"
+      "bin",
+      "sample"
     ],
     "unmockedModulePathPatterns": [
       "node_modules/"

--- a/sample/__testfixtures__/reverse-identifiers.input.js
+++ b/sample/__testfixtures__/reverse-identifiers.input.js
@@ -1,0 +1,3 @@
+var firstWord = 'Hello ';
+var secondWord = 'world';
+var message = firstWord + secondWord;

--- a/sample/__testfixtures__/reverse-identifiers.output.js
+++ b/sample/__testfixtures__/reverse-identifiers.output.js
@@ -1,0 +1,3 @@
+var droWtsrif = 'Hello ';
+var droWdnoces = 'world';
+var egassem = droWtsrif + droWdnoces;

--- a/sample/__tests__/reverse-identifiers-test.js
+++ b/sample/__tests__/reverse-identifiers-test.js
@@ -1,0 +1,22 @@
+/**
+ *  Copyright (c) 2016-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/**
+ * An example of writing a unit test for a jscodeshift script using the
+ * `runTest` helper bundled with jscodeshift. This will run the
+ * reverse-identifiers.js transform with the input specified in the
+ * reverse-identifiers-input file, and expect the output to be the same as that
+ * in reverse-identifiers-output.
+ */
+
+
+jest.autoMockOff();
+const defineTest = require('../../dist/testUtils').defineTest;
+
+defineTest(__dirname, 'reverse-identifiers');

--- a/sample/reverse-identifiers.js
+++ b/sample/reverse-identifiers.js
@@ -1,0 +1,26 @@
+/**
+ *  Copyright (c) 2016-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/**
+ * Example jscodeshift transformer. Simply reverses the names of all
+ * identifiers.
+ */
+function transformer(file, api) {
+  const j = api.jscodeshift;
+  const {expression, statement, statements} = j.template;
+
+  return j(file.source)
+    .find(j.Identifier)
+    .replaceWith(
+      p => j.identifier(p.node.name.split('').reverse().join(''))
+    )
+    .toSource();
+};
+
+module.exports = transformer;

--- a/src/testUtils.js
+++ b/src/testUtils.js
@@ -1,0 +1,78 @@
+/**
+ *  Copyright (c) 2016-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* global expect, define, it */
+
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Utility function to run a jscodeshift script within a unit test. This makes
+ * several assumptions about the environment:
+ *
+ * - `dirName` contains the name of the directory the test is located in. This
+ *   should normally be passed via __dirname.
+ * - The test should be located in a subdirectory next to the transform itself.
+ *   Commonly tests are located in a directory called __tests__.
+ * - `transformName` contains the filename of the transform being tested,
+ *   excluding the .js extension.
+ * - `testFilePrefix` optionally contains the name of the file with the test
+ *   data. If not specified, it defaults to the same value as `transformName`.
+ *   This will be suffixed with ".input.js" for the input file and ".output.js"
+ *   for the expected output. For example, if set to "foo", we will read the
+ *   "foo.input.js" file, pass this to the transform, and expect its output to
+ *   be equal to the contents of "foo.output.js".
+ * - Test data should be located in a directory called __testfixtures__
+ *   alongside the transform and __tests__ directory.
+ */
+export function runTest(dirName, transformName, options, testFilePrefix) {
+  if (!testFilePrefix) {
+    testFilePrefix = transformName;
+  }
+
+  const fixtureDir = path.join(dirName, '..', '__testfixtures__');
+  const inputPath = path.join(fixtureDir, testFilePrefix + '.input.js');
+  const source = fs.readFileSync(inputPath, 'utf8');
+  const expectedOutput = fs.readFileSync(
+    path.join(fixtureDir, testFilePrefix + '.output.js'),
+    'utf8'
+  );
+  // Assumes transform is one level up from __tests__ directory
+  let transform = require(path.join(dirName, '..', transformName + '.js'));
+  // Handle ES6 modules using default export for the transform
+  if (transform.default) {
+    transform = transform.default;
+  }
+
+  // Jest resets the module registry after each test, so we need to always get
+  // a fresh copy of jscodeshift on every test run.
+  const jscodeshift = require('./core');
+
+  const output = transform(
+    {path: inputPath, source},
+    {jscodeshift},
+    options || {}
+  );
+  expect((output || '').trim()).toEqual(expectedOutput.trim());
+}
+
+/**
+ * Handles some boilerplate around defining a simple jest/Jasmine test for a
+ * jscodeshift transform.
+ */
+export function defineTest(dirName, transformName, options, testFilePrefix) {
+  var testName = testFilePrefix
+    ? `transforms correctly using "${testFilePrefix}" data`
+    : 'transforms correctly';
+  describe(transformName, () => {
+    it(testName, () => {
+      runTest(dirName, transformName, options, testFilePrefix);
+    });
+  });
+}


### PR DESCRIPTION
Adds a simple utility to allow unit testing of jscodeshift transforms in a standard way, without having to write a bunch of boilerplate code. This is loosely based off [the technique used in react-codemod](https://github.com/reactjs/react-codemod/blob/master/jest/env.js#L23), with some changes. The main change is that where possible it doesn't depend on any global environment/configuration:

 - It's in an actual module rather than a global function called "test". It took me *so long* to work out where the `test` function was coming from in the `js-codemod` repo :stuck_out_tongue: 
 - Assumes the transform is in the parent directory of the test (eg. transform is at `foo/bar.js`, test is at `foo/__tests__/bar-test.js`)
 - Does not use a `.js` suffix for the test fixtures (input and expected output). This is mainly so they don't accidentally get picked up as unit tests by Jest, or as code that should be bundled with the app.

Also included an example of how to use it, using a simple transform (the default example from AST Explorer).