### PR TITLE
Can ignore paths before jscodeshift runs

### DIFF
--- a/bin/__tests__/jscodeshift-test.js
+++ b/bin/__tests__/jscodeshift-test.js
@@ -180,6 +180,30 @@ describe('jscodeshift CLI', () => {
     );
   });
 
+  describe('ignoring', () => {
+    var transform = createTransformWith(
+      'return "transform" + fileInfo.source;'
+    );
+    var sources = [];
+
+    beforeEach(() => {
+      sources = [];
+      sources.push(createTempFileWith('a', 'a.js'));
+      sources.push(createTempFileWith('a', 'a-test.js'));
+      // sources.push(createTempFileWith('b', 'src/lib/b.js'));
+    });
+
+    pit('does not transform files matched with --ignore-pattern', () => {
+      var pattern = '*-test.js';
+      return run(['-t', transform, '--ignore-pattern', pattern, ...sources]).then(
+        ([stdout, stderr]) => {
+          expect(fs.readFileSync(sources[0]).toString()).toBe('transforma');
+          expect(fs.readFileSync(sources[1]).toString()).toBe('a');
+        }
+      );
+    });
+  });
+
   describe('output', () => {
     pit('shows workers info and stats at the end by default', () => {
       var source = createTempFileWith('a');

--- a/bin/__tests__/jscodeshift-test.js
+++ b/bin/__tests__/jscodeshift-test.js
@@ -193,12 +193,22 @@ describe('jscodeshift CLI', () => {
       // sources.push(createTempFileWith('b', 'src/lib/b.js'));
     });
 
-    pit('does not transform files matched with --ignore-pattern', () => {
+    pit('supports basic glob', () => {
       var pattern = '*-test.js';
       return run(['-t', transform, '--ignore-pattern', pattern, ...sources]).then(
         ([stdout, stderr]) => {
           expect(fs.readFileSync(sources[0]).toString()).toBe('transforma');
           expect(fs.readFileSync(sources[1]).toString()).toBe('a');
+        }
+      );
+    });
+
+    pit('supports filename match', () => {
+      var pattern = 'a.js';
+      return run(['-t', transform, '--ignore-pattern', pattern, ...sources]).then(
+        ([stdout, stderr]) => {
+          expect(fs.readFileSync(sources[0]).toString()).toBe('a');
+          expect(fs.readFileSync(sources[1]).toString()).toBe('transforma');
         }
       );
     });

--- a/bin/__tests__/jscodeshift-test.js
+++ b/bin/__tests__/jscodeshift-test.js
@@ -215,6 +215,16 @@ describe('jscodeshift CLI', () => {
       );
     });
 
+    pit('accepts a list of patterns', () => {
+      var patterns = ['--ignore-pattern', 'a.js', '--ignore-pattern', '*-test.js'];
+      return run(['-t', transform, ...patterns, ...sources]).then(
+        ([stdout, stderr]) => {
+          expect(fs.readFileSync(sources[0]).toString()).toBe('a');
+          expect(fs.readFileSync(sources[1]).toString()).toBe('a');
+        }
+      );
+    });
+
     pit('sources ignore patterns from configuration file', () => {
       var patterns = ['sub/dir/', '*-test.js'];
       var gitignore = createTempFileWith(patterns.join('\n'), '.gitignore');

--- a/bin/__tests__/jscodeshift-test.js
+++ b/bin/__tests__/jscodeshift-test.js
@@ -238,6 +238,21 @@ describe('jscodeshift CLI', () => {
         }
       );
     });
+
+    pit('accepts a list of configuration files', () => {
+      var gitignore = createTempFileWith(['sub/dir/'].join('\n'), '.gitignore');
+      var eslintignore = createTempFileWith(['**/*test.js', 'a.js'].join('\n'), '.eslintignore');
+      var configs = ['--ignore-config', gitignore, '--ignore-config', eslintignore];
+      sources.push(createTempFileWith('subfile', 'sub/dir/file.js'));
+
+      return run(['-t', transform, ...configs, ...sources]).then(
+        ([stdout, stderr]) => {
+          expect(fs.readFileSync(sources[0]).toString()).toBe('a');
+          expect(fs.readFileSync(sources[1]).toString()).toBe('a');
+          expect(fs.readFileSync(sources[2]).toString()).toBe('subfile');
+        }
+      );
+    });
   });
 
   describe('output', () => {

--- a/bin/jscodeshift.sh
+++ b/bin/jscodeshift.sh
@@ -59,6 +59,10 @@ var opts = require('nomnom')
       default: 'js',
       help: 'File extensions the transform file should be applied to'
     },
+    ignorePattern: {
+      full: 'ignore-pattern',
+      help: 'Ignore files that match a provided glob expression'
+    },
     runInBand: {
       flag: true,
       default: false,

--- a/bin/jscodeshift.sh
+++ b/bin/jscodeshift.sh
@@ -66,6 +66,7 @@ var opts = require('nomnom')
     },
     ignoreConfig: {
       full: 'ignore-config',
+      list: true,
       help: 'Ignore files if they match patterns sourced from a configuration file (e.g., a .gitignore)',
       metavar: 'FILE'
     },

--- a/bin/jscodeshift.sh
+++ b/bin/jscodeshift.sh
@@ -63,6 +63,11 @@ var opts = require('nomnom')
       full: 'ignore-pattern',
       help: 'Ignore files that match a provided glob expression'
     },
+    ignoreConfig: {
+      full: 'ignore-config',
+      help: 'Ignore files if they match patterns sourced from a configuration file (e.g., a .gitignore)',
+      metavar: 'FILE'
+    },
     runInBand: {
       flag: true,
       default: false,

--- a/bin/jscodeshift.sh
+++ b/bin/jscodeshift.sh
@@ -61,6 +61,7 @@ var opts = require('nomnom')
     },
     ignorePattern: {
       full: 'ignore-pattern',
+      list: true,
       help: 'Ignore files that match a provided glob expression'
     },
     ignoreConfig: {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
   "devDependencies": {
     "babel": "^5.6.14",
     "babel-jest": "^5.3.0",
-    "jest-cli": "^0.9.0"
+    "jest-cli": "^0.9.0",
+    "mkdirp": "^0.5.1"
   },
   "jest": {
     "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "colors": "^1.1.2",
     "es6-promise": "^3.0.0",
     "lodash": "^3.5.0",
+    "micromatch": "^2.3.7",
     "node-dir": "0.1.8",
     "nomnom": "^1.8.1",
     "recast": "^0.11.0",

--- a/src/Runner.js
+++ b/src/Runner.js
@@ -88,9 +88,7 @@ function dirFiles (dir, callback, acc) {
           );
           done();
         } else if (ignores.shouldIgnore(name)) {
-          process.stdout.write(
-            'Ignoring path "' + name + '".\n'
-          );
+          // ignore the path
           done();
         } else if (stats.isDirectory()) {
           dirFiles(name + '/', callback, acc);
@@ -120,9 +118,7 @@ function getAllFiles(paths, filter) {
             list => resolve(list.filter(filter))
           );
         } else if (ignores.shouldIgnore(file)) {
-          process.stdout.write(
-            'Ignoring file "' + file + '".\n'
-          );
+          // ignoring the file
           resolve([]);
         } else {
           resolve([file]);

--- a/src/Runner.js
+++ b/src/Runner.js
@@ -45,8 +45,18 @@ const log = {
 
 const matchers = [];
 
+function addIgnorePattern(val) {
+  if (val && typeof val === 'string') {
+    let pattern = val;
+    if (pattern.indexOf('/') === -1) {
+      matchers.push('**/' + pattern);
+    }
+    matchers.push(pattern);
+  }
+}
+
 function shouldIgnore(path) {
-  var matched = matchers.length ? mm.any(path, matchers, { dot:true, matchBase:true }) : false;
+  var matched = matchers.length ? mm.any(path, matchers, { dot:true }) : false;
   return matched;
 }
 
@@ -148,9 +158,7 @@ function run(transformFile, paths, options) {
   const statsCounter = {};
   const startTime = process.hrtime();
 
-  if (options.ignorePattern && typeof options.ignorePattern === 'string') {
-    matchers.push(options.ignorePattern);
-  }
+  addIgnorePattern(options.ignorePattern);
 
   if (/^http/.test(transformFile)) {
     usedRemoteScript = true;

--- a/src/Runner.js
+++ b/src/Runner.js
@@ -50,6 +50,9 @@ function addIgnorePattern(val) {
     let pattern = val;
     if (pattern.indexOf('/') === -1) {
       matchers.push('**/' + pattern);
+    } else if (pattern[pattern.length-1] === '/') {
+      matchers.push('**/' + pattern + '**');
+      matchers.push(pattern + '**');
     }
     matchers.push(pattern);
   }
@@ -159,6 +162,23 @@ function run(transformFile, paths, options) {
   const startTime = process.hrtime();
 
   addIgnorePattern(options.ignorePattern);
+
+  if (options.ignoreConfig) {
+    let lines = [];
+
+    if (typeof options.ignoreConfig === 'string') {
+      options.ignoreConfig = [options.ignoreConfig];
+    }
+    options.ignoreConfig.forEach(function(config) {
+      var stats = fs.statSync(config);
+      if (stats.isFile()) {
+        var content = fs.readFileSync(config, 'utf8');
+        lines = lines.concat(content.split('\n'));
+      }
+    });
+
+    lines.forEach(addIgnorePattern);
+  }
 
   if (/^http/.test(transformFile)) {
     usedRemoteScript = true;

--- a/src/ignoreFiles.js
+++ b/src/ignoreFiles.js
@@ -5,6 +5,12 @@ const mm = require('micromatch');
 
 const matchers = [];
 
+/**
+ * Add glob patterns to ignore matched files and folders.
+ * Creates glob patterns to approximate gitignore patterns.
+ * @param {String} val - the glob or gitignore-style pattern to ignore
+ * @see {@linkplain https://git-scm.com/docs/gitignore#_pattern_format}
+ */
 function addIgnorePattern(val) {
   if (val && typeof val === 'string') {
     let pattern = val;
@@ -18,6 +24,22 @@ function addIgnorePattern(val) {
   }
 }
 
+/**
+ * Adds ignore patterns directly from function input
+ * @param {String|Array<String>} input - the ignore patterns
+ */
+function addIgnoreFromInput(input) {
+  let patterns = [];
+  if (input) {
+    patterns = patterns.concat(input);
+  }
+  patterns.forEach(addIgnorePattern);
+}
+
+/**
+ * Adds ignore patterns by reading files
+ * @param {String|Array<String>} input - the paths to the ignore config files
+ */
 function addIgnoreFromFile(input) {
   let lines = [];
   let files = [];
@@ -41,6 +63,6 @@ function shouldIgnore(path) {
   return matched;
 }
 
-exports.add = addIgnorePattern;
+exports.add = addIgnoreFromInput;
 exports.addFromFile = addIgnoreFromFile;
 exports.shouldIgnore = shouldIgnore;

--- a/src/ignoreFiles.js
+++ b/src/ignoreFiles.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const fs = require('fs');
+const mm = require('micromatch');
+
+const matchers = [];
+
+function addIgnorePattern(val) {
+  if (val && typeof val === 'string') {
+    let pattern = val;
+    if (pattern.indexOf('/') === -1) {
+      matchers.push('**/' + pattern);
+    } else if (pattern[pattern.length-1] === '/') {
+      matchers.push('**/' + pattern + '**');
+      matchers.push(pattern + '**');
+    }
+    matchers.push(pattern);
+  }
+}
+
+function addIgnoreFromFile(input) {
+  let lines = [];
+  let files = [];
+  if (input) {
+    files = files.concat(input);
+  }
+
+  files.forEach(function(config) {
+    var stats = fs.statSync(config);
+    if (stats.isFile()) {
+      var content = fs.readFileSync(config, 'utf8');
+      lines = lines.concat(content.split('\n'));
+    }
+  });
+
+  lines.forEach(addIgnorePattern);
+}
+
+function shouldIgnore(path) {
+  var matched = matchers.length ? mm.any(path, matchers, { dot:true }) : false;
+  return matched;
+}
+
+exports.add = addIgnorePattern;
+exports.addFromFile = addIgnoreFromFile;
+exports.shouldIgnore = shouldIgnore;


### PR DESCRIPTION
Fixes #53.

Usage:

```
# will ignore paths matching the glob
jscodeshift -t transform.js --ignore-pattern="*-test.js" ~/path/to/repo

# will ignore all files gitignore does
jscodeshift -t transform.js --ignore-config ~/path/to/repo/.gitignore ~/path/to/repo
```

The implementation could probably be made more robust by pulling in another package like `gitignore-to-glob`, but I tried to keep the dependency tree pretty much as-is.