### PR TITLE
Provide plugin registration method that avoids duplicate registrations.

### DIFF
--- a/src/__tests__/core-test.js
+++ b/src/__tests__/core-test.js
@@ -54,5 +54,25 @@ describe('core API', function() {
     var source = '\nvar foo;\n';
     expect(core(source).toSource()).toEqual(source);
   });
+  
+  it('plugins are called with core', function (done) {
+    core.use(function (j) {
+      expect(j).toBe(core);
+      done();
+    });
+  });
+  
+  it('plugins are only registered once', function () {
+    var ct = 0;
+    
+    function plugin() {
+      ct++;
+    }
+    
+    core.use(plugin);
+    core.use(plugin);
+    
+    expect(ct).toBe(1);
+  });
 
 });

--- a/src/core.js
+++ b/src/core.js
@@ -112,4 +112,24 @@ for (var name in collections) {
   }
 }
 
+var plugins = [];
+
+/**
+ * Utility function for registering plugins.
+ * 
+ * Plugins are simple functions that are passed the core jscodeshift instance. 
+ * They should extend jscodeshift by call `registerMethods`, etc.
+ * This method guards against repeated registrations (the plugin callback will only be called once).
+ * 
+ * @param {Function} plugin
+ */
+function use(plugin) {
+  if (plugins.indexOf(plugin) === -1) {
+    plugins.push(plugin);
+    plugin(core);
+  }
+}
+
+core.use = use;
+
 module.exports = core;


### PR DESCRIPTION
Provides a `use` method on core that can be used to register extensions.
It avoids calling the same extension multiple times which is useful during testing.