### PR TITLE
Allow non-conflicting method registrations. Fixes #109.

### DIFF
--- a/src/Collection.js
+++ b/src/Collection.js
@@ -302,7 +302,25 @@ function registerMethods(methods, type) {
       return;
     }
     if (hasConflictingRegistration(methodName, type)) {
-      throw Error(`There is a conflicting registration for method with name "${methodName}".`);
+      var msg = `There is a conflicting registration for method with name "${methodName}".\nYou tried to register an additional method with `;
+      
+      if (type) {
+        msg += `type "${type.toString()}".`
+      } else {
+        msg += 'universal type.'
+      }
+      
+      msg += '\nThere are existing registrations for that method with ';
+      
+      var conflictingRegistrations = CPt[methodName].typedRegistrations;
+      
+      if (conflictingRegistrations) {
+        msg += `type ${Object.keys(conflictingRegistrations).join(', ')}.`; 
+      } else {
+        msg += 'universal type.';
+      }
+      
+      throw Error(msg);
     }
     if (!type) {
       CPt[methodName] = methods[methodName];

--- a/src/__tests__/Collection-test.js
+++ b/src/__tests__/Collection-test.js
@@ -168,6 +168,32 @@ describe('Collection API', function() {
         collection.foo();
       }).toThrow();
     });
+    
+    describe('hasConflictingRegistration', function () {
+      function register(methodName, type) {
+        var methods = {};
+        methods[methodName] = function () {};
+        if (!types[type]) {
+          throw new Error(type + ' is not a valid type');
+        }
+        Collection.registerMethods(methods, types[type]);
+      }
+      
+      it('true if supertype is registered', function () {
+        register('supertypeIsRegistered', 'Expression');
+        expect(Collection.hasConflictingRegistration('supertypeIsRegistered', 'FunctionExpression')).toBe(true);
+      });
+      
+      it('true if subtype is registered', function () {
+        register('subtypeIsRegistered', 'FunctionExpression');
+        expect(Collection.hasConflictingRegistration('subtypeIsRegistered', 'Expression')).toBe(true);
+      });
+      
+      it('false if only a sibling type is registered', function () {
+        register('siblingIsRegistered', 'FunctionExpression');
+        expect(Collection.hasConflictingRegistration('siblingIsRegistered', 'BinaryExpression')).toBe(false);
+      });
+    });
   });
 
   describe('Processing functions', function() {


### PR DESCRIPTION
This allows you to register multiple typed methods with the same methodName, as long as there is no type overlap.

I've only added one additional unit test, though it might be wise to add a few more for the `hasConflictingRegistration` method.