### PR TITLE
Allow return many files from transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Options:
    -p, --print                 Print output, useful for development
    --babel                     Apply Babel to transform files  [true]
    --extensions                File extensions the transform file should be applied to  [js]
+   --ignore-pattern            Ignore files that match a provided glob expression
+   --ignore-config FILE        Ignore files if they match patterns sourced from a configuration file (e.g., a .gitignore)
+   --run-in-band               Run serially in the current process  [false]
+   -s, --silent                No output  [false]
 ```
 
 This passes the source of all passed through the transform module specified

--- a/bin/__tests__/jscodeshift-test.js
+++ b/bin/__tests__/jscodeshift-test.js
@@ -182,6 +182,26 @@ describe('jscodeshift CLI', () => {
     );
   });
 
+  pit('transform can return list of files', () => {
+    var source = createTempFileWith('a_b');
+    var secondFile = temp.path({suffix: '.js'});
+
+    var transform = createTransformWith(
+      `return fileInfo.source.split('_')
+        .map((source, i) => i === 0 ?
+          {source, path: fileInfo.path} :
+          {source, path: '${secondFile}'})`
+    );
+
+    return run(['-t', transform, source]).then(
+      ([stdout, stderr]) => {
+        expect(fs.readFileSync(source).toString()).toBe('a');
+        expect(fs.readFileSync(secondFile).toString()).toBe('b');
+      }
+    );
+  });
+
+
   describe('ignoring', () => {
     var transform = createTransformWith(
       'return "transform" + fileInfo.source;'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jscodeshift",
-  "version": "0.3.19",
+  "version": "0.3.20",
   "description": "A toolkit for JavaScript codemods",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "node-dir": "0.1.8",
     "nomnom": "^1.8.1",
     "recast": "^0.11.0",
-    "temp": "^0.8.1"
+    "temp": "^0.8.1",
+    "write": "^0.3.1"
   },
   "devDependencies": {
     "babel": "^5.6.14",

--- a/src/Collection.js
+++ b/src/Collection.js
@@ -133,14 +133,17 @@ class Collection {
     return this.__paths;
   }
 
-  toSource(options) {
+  toSource(options, isPretty = false) {
     if (this._parent) {
       return this._parent.toSource(options);
     }
+    const printer = isPretty ?
+        (...args) => recast.prettyPrint(...args) :
+        (...args) => recast.pretty(...args);
     if (this.__paths.length === 1) {
-      return recast.print(this.__paths[0], options).code;
+      return printer(this.__paths[0], options).code;
     } else {
-      return this.__paths.map(p => recast.print(p, options).code);
+      return this.__paths.map(p => printer(p, options).code);
     }
   }
 

--- a/src/Runner.js
+++ b/src/Runner.js
@@ -41,6 +41,9 @@ const log = {
   error(msg, verbose) {
     verbose >= 0 && process.stdout.write(colors.white.bgRed(' ERR ') + msg);
   },
+  create(msg, verbose) {
+    verbose >= 1 && process.stdout.write(colors.white.bgYellow(' CREATE ') + msg);
+  }
 };
 
 function showFileStats(fileStats) {

--- a/src/Worker.js
+++ b/src/Worker.js
@@ -15,7 +15,7 @@ const EventEmitter = require('events').EventEmitter;
 const async = require('async');
 const fs = require('fs');
 const writeFile = require('write');
-const _ = require('lodash')
+const _ = require('lodash');
 const jscodeshift = require('./core');
 
 let emitter;
@@ -138,7 +138,7 @@ function run(data) {
               async.each(
                 out,
                 function (outFile, outCallback) {
-                  // Create any intermediate directories if they don't already exist
+                  // Create file with any intermediate directories
                   writeFile(
                     outFile.path,
                     outFile.source,

--- a/src/__tests__/Collection-test.js
+++ b/src/__tests__/Collection-test.js
@@ -264,5 +264,12 @@ describe('Collection API', function() {
       });
     });
 
+    describe('toSource with isPretty', function() {
+      it('should use pretty print', function() {
+        var root = Collection.fromNodes([recast.parse('props => {}')]);
+        root.paths()[0].value.program.body[0].expression.params[0].typeAnnotation = b.typeAnnotation(b.genericTypeAnnotation(b.identifier('Props'), null))
+        expect(root.toSource({}, true)).toEqual('(props: Props) => {};');
+      });
+    });
   });
 });


### PR DESCRIPTION
Type: feature proposal
Description: allow return array from `transform` function. Array must contains objects with `path` and `source` props.
Example:
`return [{path: '/path/to/file1', source: 'someContent1'}, {path: '/path/to/file2', source: 'someContent2'}]`
Stage: draft
Also I want allow pass one object in array without prop `path` or just string i.e:
`return [{source: 'someContent1'}, {path: '/path/to/file2', source: 'someContent2'}]`
or
`return ['someContent1', {path: '/path/to/file2', source: 'someContent2'}]`
In this case `path` be equal to path source file.
Also need to add some checks for array of files.
Motivation: many kinds of refactoring include split big one file to many files. With ability to return many files will be able to make codemods such as:
- `codemod-split-utils-file` - I will be split file with many exported functions to many files according the rule "one file - one function". Source file will used as entry point and contatins only `export from` statements.
- `codemod-split-components-to-files` - It is the same as the previous but for React component
- `codemod-export-complex-flow-type` - It move big and complex type annotations in separate file
  Also I want add to [codemod-proptypes-to-flow](https://github.com/billyvg/codemod-proptypes-to-flow) option for place generated annotation in separate file(something like `Component.js.flow` for `Component.jsx`).

What do you think?
