### PR TITLE
Upgrade recast to ^0.11.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "micromatch": "^2.3.7",
     "node-dir": "0.1.8",
     "nomnom": "^1.8.1",
-    "recast": "^0.11.0",
+    "recast": "^0.11.8",
     "temp": "^0.8.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixed the issue of not printing return type in arrow function expressions (benjamn/recast#289). Thanks!