### PR TITLE
Add note about remote transforms to CLI --help and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Usage: jscodeshift <path>... [options]
 path     Files or directory to transform
 
 Options:
-   -t FILE, --transform FILE   Path to the transform file  [./transform.js]
+   -t FILE, --transform FILE   Path to the transform file. Can be either a local path or url  [./transform.js]
    -c, --cpus                  (all by default) Determines the number of processes started.
    -v, --verbose               Show more information about the transform process  [0]
    -d, --dry                   Dry run (no changes are made to files)

--- a/bin/jscodeshift.sh
+++ b/bin/jscodeshift.sh
@@ -27,7 +27,7 @@ var opts = require('nomnom')
     transform: {
       abbr: 't',
       default: './transform.js',
-      help: 'Path to the transform file',
+      help: 'Path to the transform file. Can be either a local path or url',
       metavar: 'FILE'
     },
     cpus: {


### PR DESCRIPTION
Added _super_ basic documentation to highlight that [remote transforms can be used](https://github.com/facebook/jscodeshift/commit/027cd027800e238e35d047654360ba08d8e3f7ea). Let me know if there are any suggestions for better verbiage.

Also, I think it might be useful to specify the limitations of this feature (primarily, that the transform must be entirely self-contained). Any suggestions on where to include that in the README?