### PR TITLE
Add the possibility to select different parsers (closes #117)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,5 +9,8 @@
   },
   "env": {
     "node": true
+  },
+  "globals": {
+    "Promise": true
   }
 }

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,8 @@
 /src/
 /sample/
 .gitignore
+.eslintrc
+.eslintrc.yaml
 .jshintrc
 .module-cache
 __tests__

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ sudo: false
 language: node_js
 node_js:
   - 4
+  - 5
   - stable

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Options:
    --ignore-config FILE        Ignore files if they match patterns sourced from a configuration file (e.g., a .gitignore)
    --run-in-band               Run serially in the current process  [false]
    -s, --silent                No output  [false]
+   --parser                    The parser to use for parsing your source files (babel | babylon | flow)  [babel]
+   --version                   print version and exit
 ```
 
 This passes the source of all passed through the transform module specified
@@ -120,7 +122,7 @@ $ jscodeshift -t myTransforms fileA fileB --foo=bar
 `options` would contain `{foo: 'bar'}`. jscodeshift uses [nomnom][] to parse
 command line options.
 
-#### Return value
+### Return value
 
 The return value of the function determines the status of the transformation:
 
@@ -136,7 +138,28 @@ detailed information by setting the `-v` option to `1` or `2`.
 
 You can collect even more stats via the `stats` function as explained above.
 
-### Example
+### Parser
+
+The transform can let jscodeshift know with which parser to parse the source 
+files (and features like templates).
+
+To do that, the transform module can export `parser`, which can either be one 
+of the strings `"babel"`, `"babylon"`, or `"flow"`, or it can be a parser 
+object that is compatible with with recast.
+
+For example:
+
+```js
+module.exports.parser = 'flow'; // use the flow parser
+// or
+module.exports.parser = {
+  parse: function(source) {
+    // return estree compatible AST
+  },
+};
+```
+
+### Example output
 
 ```text
 $ jscodeshift -t myTransform.js src
@@ -292,6 +315,13 @@ This can be done by passing config options to [recast].
 
 ```js
 .toSource({quote: 'single'}); // sets strings to use single quotes in transformed code.
+```
+
+You can also pass options to recast's `parse` method by passing an object to 
+jscodeshift as second argument:
+
+```js
+jscodeshift(source, {...})
 ```
 
 More on config options [here](https://github.com/benjamn/recast/blob/52a7ec3eaaa37e78436841ed8afc948033a86252/lib/options.js#L61)

--- a/bin/__tests__/jscodeshift-test.js
+++ b/bin/__tests__/jscodeshift-test.js
@@ -8,20 +8,23 @@
  *
  */
 
-/*global jest, jasmine, describe, pit, expect*/
+/*global jest, jasmine, describe, it, expect, beforeEach*/
 /*eslint camelcase: 0, no-unused-vars: 0*/
 
 jest.autoMockOff();
 
 // Increase default timeout (5000ms) for Travis
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 600000; // 10 minutes
 
 var child_process = require('child_process');
 var fs = require('fs');
 var path = require('path');
 var temp = require('temp');
 var mkdirp = require('mkdirp');
-require('es6-promise').polyfill();
+var testUtils = require('../../utils/testUtils');
+
+var createTransformWith = testUtils.createTransformWith;
+var createTempFileWith = testUtils.createTempFileWith;
 
 function run(args, stdin, cwd) {
   return new Promise(resolve => {
@@ -45,32 +48,8 @@ function run(args, stdin, cwd) {
 }
 
 describe('jscodeshift CLI', () => {
-  function createTempFileWith(content, filename) {
-    var info = temp.openSync();
-    var filePath = info.path;
-    fs.writeSync(info.fd, content);
-    fs.closeSync(info.fd);
-    if (filename) {
-      filePath = renameFileTo(filePath, filename);
-    }
-    return filePath;
-  }
 
-  function renameFileTo(oldPath, newFilename) {
-    var projectPath = path.dirname(oldPath);
-    var newPath = path.join(projectPath, newFilename);
-    mkdirp.sync(path.dirname(newPath));
-    fs.renameSync(oldPath, newPath);
-    return newPath;
-  }
-
-  function createTransformWith(content) {
-    return createTempFileWith(
-      'module.exports = function(fileInfo, api, options) { ' + content + ' }'
-    );
-  }
-
-  pit('calls the transform and file information', () => {
+  it('calls the transform and file information', () => {
     var sourceA = createTempFileWith('a');
     var sourceB = createTempFileWith('b\n');
     var sourceC = createTempFileWith('c');
@@ -83,45 +62,47 @@ describe('jscodeshift CLI', () => {
 
     return Promise.all([
       run(['-t', transformA, sourceA, sourceB]).then(
-        ([stdout, stderr]) => {
+        out => {
+          expect(out[1]).toBe('');
           expect(fs.readFileSync(sourceA).toString()).toBe('transforma');
           expect(fs.readFileSync(sourceB).toString()).toBe('transformb\n');
         }
       ),
       run(['-t', transformB, sourceC]).then(
-        ([stdout, stderr]) => {
+        out => {
+          expect(out[1]).toBe('');
           expect(fs.readFileSync(sourceC).toString()).toBe(sourceC);
         }
       )
     ]);
   });
 
-  pit('does not transform files in a dry run', () => {
+  it('does not transform files in a dry run', () => {
     var source = createTempFileWith('a');
     var transform = createTransformWith(
       'return "transform" + fileInfo.source;'
     );
     return run(['-t', transform, '-d', source]).then(
-      ([stdout, stderr]) => {
+      () => {
         expect(fs.readFileSync(source).toString()).toBe('a');
       }
     );
   });
 
-  pit('loads transform files with Babel if not disabled', () => {
+  it('loads transform files with Babel if not disabled', () => {
     var source = createTempFileWith('a');
     var transform = createTransformWith(
       'return (function() { "use strict"; const a = 42; }).toString();'
     );
     return Promise.all([
       run(['-t', transform, source]).then(
-        ([stdout, stderr]) => {
+        () => {
           expect(fs.readFileSync(source).toString())
             .toMatch(/var\s*a\s*=\s*42/);
         }
       ),
       run(['-t', transform, '--no-babel', source]).then(
-        ([stdout, stderr]) => {
+        () => {
           expect(fs.readFileSync(source).toString())
             .toMatch(/const\s*a\s*=\s*42/);
         }
@@ -129,7 +110,7 @@ describe('jscodeshift CLI', () => {
     ]);
   });
 
-  pit('ignores .babelrc files in the directories of the source files', () => {
+  it('ignores .babelrc files in the directories of the source files', () => {
     var transform = createTransformWith(
       'return (function() { "use strict"; const a = 42; }).toString();'
     );
@@ -137,14 +118,14 @@ describe('jscodeshift CLI', () => {
     var source = createTempFileWith('a', 'source.js');
 
     return run(['-t', transform, source]).then(
-      ([stdout, stderr]) => {
+      () => {
         expect(fs.readFileSync(source).toString())
           .toMatch(/var\s*a\s*=\s*42/);
       }
     );
   });
 
-  pit('passes jscodeshift and stats the transform function', () => {
+  it('passes jscodeshift and stats the transform function', () => {
     var source = createTempFileWith('a');
     var transform = createTransformWith([
       '  return String(',
@@ -153,30 +134,30 @@ describe('jscodeshift CLI', () => {
       '  );',
     ].join('\n'));
     return run(['-t', transform, source]).then(
-      ([stdout, stderr]) => {
+      () => {
         expect(fs.readFileSync(source).toString()).toBe('true');
       }
     );
   });
 
-  pit('passes options along to the transform', () => {
+  it('passes options along to the transform', () => {
     var source = createTempFileWith('a');
     var transform = createTransformWith('return options.foo;');
     return run(['-t', transform, '--foo=42', source]).then(
-      ([stdout, stderr]) => {
+      () => {
         expect(fs.readFileSync(source).toString()).toBe('42');
       }
     );
   });
 
-  pit('does not stall with too many files', () => {
+  it('does not stall with too many files', () => {
     var sources = [];
     for (var i = 0; i < 100; i++) {
       sources.push(createTempFileWith('a'));
     }
     var transform = createTransformWith('');
     return run(['-t', transform, '--foo=42'].concat(sources)).then(
-      ([stdout, stderr]) => {
+      () => {
         expect(true).toBe(true);
       }
     );
@@ -195,43 +176,43 @@ describe('jscodeshift CLI', () => {
       // sources.push(createTempFileWith('b', 'src/lib/b.js'));
     });
 
-    pit('supports basic glob', () => {
+    it('supports basic glob', () => {
       var pattern = '*-test.js';
-      return run(['-t', transform, '--ignore-pattern', pattern, ...sources]).then(
-        ([stdout, stderr]) => {
+      return run(['-t', transform, '--ignore-pattern', pattern].concat(sources)).then(
+        () => {
           expect(fs.readFileSync(sources[0]).toString()).toBe('transforma');
           expect(fs.readFileSync(sources[1]).toString()).toBe('a');
         }
       );
     });
 
-    pit('supports filename match', () => {
+    it('supports filename match', () => {
       var pattern = 'a.js';
-      return run(['-t', transform, '--ignore-pattern', pattern, ...sources]).then(
-        ([stdout, stderr]) => {
+      return run(['-t', transform, '--ignore-pattern', pattern].concat(sources)).then(
+        () => {
           expect(fs.readFileSync(sources[0]).toString()).toBe('a');
           expect(fs.readFileSync(sources[1]).toString()).toBe('transforma');
         }
       );
     });
 
-    pit('accepts a list of patterns', () => {
+    it('accepts a list of patterns', () => {
       var patterns = ['--ignore-pattern', 'a.js', '--ignore-pattern', '*-test.js'];
-      return run(['-t', transform, ...patterns, ...sources]).then(
-        ([stdout, stderr]) => {
+      return run(['-t', transform].concat(patterns).concat(sources)).then(
+        () => {
           expect(fs.readFileSync(sources[0]).toString()).toBe('a');
           expect(fs.readFileSync(sources[1]).toString()).toBe('a');
         }
       );
     });
 
-    pit('sources ignore patterns from configuration file', () => {
+    it('sources ignore patterns from configuration file', () => {
       var patterns = ['sub/dir/', '*-test.js'];
       var gitignore = createTempFileWith(patterns.join('\n'), '.gitignore');
       sources.push(createTempFileWith('subfile', 'sub/dir/file.js'));
 
-      return run(['-t', transform, '--ignore-config', gitignore, ...sources]).then(
-        ([stdout, stderr]) => {
+      return run(['-t', transform, '--ignore-config', gitignore].concat(sources)).then(
+        () => {
           expect(fs.readFileSync(sources[0]).toString()).toBe('transforma');
           expect(fs.readFileSync(sources[1]).toString()).toBe('a');
           expect(fs.readFileSync(sources[2]).toString()).toBe('subfile');
@@ -239,14 +220,14 @@ describe('jscodeshift CLI', () => {
       );
     });
 
-    pit('accepts a list of configuration files', () => {
+    it('accepts a list of configuration files', () => {
       var gitignore = createTempFileWith(['sub/dir/'].join('\n'), '.gitignore');
       var eslintignore = createTempFileWith(['**/*test.js', 'a.js'].join('\n'), '.eslintignore');
       var configs = ['--ignore-config', gitignore, '--ignore-config', eslintignore];
       sources.push(createTempFileWith('subfile', 'sub/dir/file.js'));
 
-      return run(['-t', transform, ...configs, ...sources]).then(
-        ([stdout, stderr]) => {
+      return run(['-t', transform].concat(configs).concat(sources)).then(
+        () => {
           expect(fs.readFileSync(sources[0]).toString()).toBe('a');
           expect(fs.readFileSync(sources[1]).toString()).toBe('a');
           expect(fs.readFileSync(sources[2]).toString()).toBe('subfile');
@@ -256,27 +237,27 @@ describe('jscodeshift CLI', () => {
   });
 
   describe('output', () => {
-    pit('shows workers info and stats at the end by default', () => {
+    it('shows workers info and stats at the end by default', () => {
       var source = createTempFileWith('a');
       var transform = createTransformWith('return null;');
       return run(['-t', transform, source]).then(
-        ([stdout, stderr]) => {
-          expect(stdout).toContain('Processing 1 files...');
-          expect(stdout).toContain('Spawning 1 workers...');
-          expect(stdout).toContain('Sending 1 files to free worker...');
-          expect(stdout).toContain('All done.');
-          expect(stdout).toContain('Results: ');
-          expect(stdout).toContain('Time elapsed: ');
+        out => {
+          expect(out[0]).toContain('Processing 1 files...');
+          expect(out[0]).toContain('Spawning 1 workers...');
+          expect(out[0]).toContain('Sending 1 files to free worker...');
+          expect(out[0]).toContain('All done.');
+          expect(out[0]).toContain('Results: ');
+          expect(out[0]).toContain('Time elapsed: ');
         }
       );
     });
 
-    pit('does not ouput anything in silent mode', () => {
+    it('does not ouput anything in silent mode', () => {
       var source = createTempFileWith('a');
       var transform = createTransformWith('return null;');
       return run(['-t', transform, '-s', source]).then(
-        ([stdout, stderr]) => {
-          expect(stdout).toEqual('');
+        out => {
+          expect(out[0]).toEqual('');
         }
       );
     });

--- a/bin/jscodeshift.sh
+++ b/bin/jscodeshift.sh
@@ -11,10 +11,11 @@
 
 'use strict';
 
-var Runner = require('../dist/Runner.js');
+const Runner = require('../src/Runner.js');
 
-var path = require('path');
-var opts = require('nomnom')
+const path = require('path');
+const pkg = require('../package.json');
+const opts = require('nomnom')
   .script('jscodeshift')
   .options({
     path: {
@@ -82,7 +83,26 @@ var opts = require('nomnom')
       default: false,
       full: 'silent',
       help: 'No output'
-    }
+    },
+    parser: {
+      choices: ['babel', 'babylon', 'flow'],
+      default: 'babel',
+      full: 'parser',
+      help: 'The parser to use for parsing your source files (babel | babylon | flow)'
+    },
+    version: {
+      flag: true,
+      help: 'print version and exit',
+      callback: function() {
+        const requirePackage = require('../utils/requirePackage');
+        return [
+          `jscodeshift: ${pkg.version}`,
+          ` - babel: ${require('babelv5').version}`,
+          ` - babylon: ${requirePackage('babylon').version}`,
+          ` - flow: ${requirePackage('flow-parser').version}`,
+        ].join('\n');
+      },
+    },
   })
   .parse();
 

--- a/package.json
+++ b/package.json
@@ -9,13 +9,15 @@
   "bugs": "https://github.com/facebook/jscodeshift/issues",
   "main": "index.js",
   "scripts": {
-    "build": "rm -rf dist; babel src/ --out-dir dist/",
-    "watch": "babel src/ --out-dir dist/ --watch",
-    "test": " npm run build && jest",
-    "prepublish": "npm run test && npm run build"
+    "build": "cp -R src/ dist/",
+    "test": "jest --bail",
+    "prepublish": "npm run build && npm run test"
   },
   "bin": {
     "jscodeshift": "./bin/jscodeshift.sh"
+  },
+  "engines": {
+    "node": ">=4"
   },
   "keywords": [
     "codemod",
@@ -25,10 +27,13 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "async": "^1.5.0",
-    "babel-core": "^5.8.21",
-    "babel-runtime": "^5.6.18",
+    "babel-preset-es2015": "^6.9.0",
+    "babel-register": "^6.9.0",
+    "babelv5": "file:packages/babelv5",
+    "babylon": "^6.8.1",
     "colors": "^1.1.2",
     "es6-promise": "^3.0.0",
+    "flow-parser": "^0.*",
     "lodash": "^3.5.0",
     "micromatch": "^2.3.7",
     "node-dir": "0.1.8",
@@ -37,14 +42,10 @@
     "temp": "^0.8.1"
   },
   "devDependencies": {
-    "babel": "^5.6.14",
-    "babel-jest": "^5.3.0",
-    "jest-cli": "^0.9.0",
+    "jest-cli": "^12.0.0",
     "mkdirp": "^0.5.1"
   },
   "jest": {
-    "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",
-    "preprocessCachingDisabled": true,
     "testPathDirs": [
       "src",
       "bin",

--- a/packages/babelv5/index.js
+++ b/packages/babelv5/index.js
@@ -1,0 +1,13 @@
+/*
+ *  Copyright (c) 2015-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+'use strict';
+
+module.exports = require('babel-core');

--- a/packages/babelv5/package.json
+++ b/packages/babelv5/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "babelv5",
+  "version": "1.0.0",
+  "description": "Wrapper to prevent version conflicts",
+  "private": true,
+  "main": "./index.js",
+  "dependencies": {
+    "babel-core": "^5"
+  }
+}

--- a/parser/babylon.js
+++ b/parser/babylon.js
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2015-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+'use strict';
+
+const babylon = require('babylon');
+
+const options = {
+  sourceType: 'module',
+  allowImportExportEverywhere: true,
+  allowReturnOutsideFunction: true,
+  plugins: [
+    'jsx',
+    'flow',
+    'asyncFunctions',
+    'classConstructorCall',
+    'doExpressions',
+    'trailingFunctionCommas',
+    'objectRestSpread',
+    'decorators',
+    'classProperties',
+    'exportExtensions',
+    'exponentiationOperator',
+    'asyncGenerators',
+    'functionBind',
+    'functionSent',
+  ],
+};
+
+/**
+ * Wrapper to set default options
+ */
+exports.parse = function parse (code) {
+  return babylon.parse(code, options);
+};

--- a/sample/__tests__/reverse-identifiers-test.js
+++ b/sample/__tests__/reverse-identifiers-test.js
@@ -15,8 +15,9 @@
  * in reverse-identifiers-output.
  */
 
+'use strict';
 
 jest.autoMockOff();
-const defineTest = require('../../dist/testUtils').defineTest;
+const defineTest = require('../../src/testUtils').defineTest;
 
 defineTest(__dirname, 'reverse-identifiers');

--- a/sample/reverse-identifiers.js
+++ b/sample/reverse-identifiers.js
@@ -13,7 +13,6 @@
  */
 function transformer(file, api) {
   const j = api.jscodeshift;
-  const {expression, statement, statements} = j.template;
 
   return j(file.source)
     .find(j.Identifier)
@@ -21,6 +20,6 @@ function transformer(file, api) {
       p => j.identifier(p.node.name.split('').reverse().join(''))
     )
     .toSource();
-};
+}
 
 module.exports = transformer;

--- a/src/Runner.js
+++ b/src/Runner.js
@@ -43,6 +43,13 @@ const log = {
   },
 };
 
+function concatAll(arrays) {
+  return arrays.reduce(
+    (result, array) => (result.push.apply(result, array), result),
+    []
+  );
+}
+
 function showFileStats(fileStats) {
   process.stdout.write(
     'Results: \n'+
@@ -104,7 +111,7 @@ function dirFiles (dir, callback, acc) {
 
 function getAllFiles(paths, filter) {
   return Promise.all(
-    paths.map(file => new Promise((resolve, reject) => {
+    paths.map(file => new Promise(resolve => {
       fs.lstat(file, (err, stat) => {
         if (err) {
           process.stderr.write('Skipping path ' + file + ' which does not exist. \n');
@@ -125,7 +132,7 @@ function getAllFiles(paths, filter) {
         }
       })
     }))
-  ).then(files => [].concat(...files));
+  ).then(concatAll);
 }
 
 function run(transformFile, paths, options) {

--- a/src/__tests__/.eslintrc.yaml
+++ b/src/__tests__/.eslintrc.yaml
@@ -1,0 +1,4 @@
+env:
+  jasmine: true
+globals:
+  jest: true

--- a/src/__tests__/.jshintrc
+++ b/src/__tests__/.jshintrc
@@ -1,5 +1,0 @@
-{
-  "predef": ["jest", "describe", "beforeEach" , "xit", "it", "expect"],
-  "node": true,
-  "esnext": true
-}

--- a/src/__tests__/Collection-test.js
+++ b/src/__tests__/Collection-test.js
@@ -135,40 +135,40 @@ describe('Collection API', function() {
       ]);
       expect(() => collection.expressionMethod()).not.toThrow();
     });
-    
+
     it('allows multiple registrations for non-conflicting types', function () {
       Collection.registerMethods(
         {foo: function () {}},
         types.FunctionExpression
       );
-      
+
       Collection.registerMethods(
         {foo: function () {}},
         types.BinaryExpression
       );
-      
+
       var collection = Collection.fromNodes([
         b.functionExpression(null, [], b.blockStatement([])),
         b.functionExpression(null, [], b.blockStatement([])),
         b.binaryExpression("+", b.identifier("a"), b.identifier("b"))
       ]);
-      
+
       function typeFilter(type) {
         return function (path) {
           return type.check(path.value);
         };
       }
-      
+
       // allowed if collection contents match one of the registered types.
       collection.filter(typeFilter(types.BinaryExpression)).foo();
       collection.filter(typeFilter(types.FunctionExpression)).foo();
-      
+
       // not allowed if there is mixed types (even though all types match one function or the other).
       expect(function () {
         collection.foo();
       }).toThrow();
     });
-    
+
     describe('hasConflictingRegistration', function () {
       function register(methodName, type) {
         var methods = {};
@@ -178,17 +178,17 @@ describe('Collection API', function() {
         }
         Collection.registerMethods(methods, types[type]);
       }
-      
+
       it('true if supertype is registered', function () {
         register('supertypeIsRegistered', 'Expression');
         expect(Collection.hasConflictingRegistration('supertypeIsRegistered', 'FunctionExpression')).toBe(true);
       });
-      
+
       it('true if subtype is registered', function () {
         register('subtypeIsRegistered', 'FunctionExpression');
         expect(Collection.hasConflictingRegistration('subtypeIsRegistered', 'Expression')).toBe(true);
       });
-      
+
       it('false if only a sibling type is registered', function () {
         register('siblingIsRegistered', 'FunctionExpression');
         expect(Collection.hasConflictingRegistration('siblingIsRegistered', 'BinaryExpression')).toBe(false);

--- a/src/__tests__/Worker-test.js
+++ b/src/__tests__/Worker-test.js
@@ -1,0 +1,105 @@
+/*
+ *  Copyright (c) 2015-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+'use strict';
+
+jest.autoMockOff();
+
+const testUtils = require('../../utils/testUtils');
+
+const createTransformWith = testUtils.createTransformWith;
+const createTempFileWith = testUtils.createTempFileWith;
+const getFileContent = testUtils.getFileContent;
+
+describe('Worker API', () => {
+  let worker;
+
+  beforeEach(() => {
+    worker = require('../Worker');
+  });
+
+  it('transforms files', done => {
+    const transformPath =
+      createTransformWith('return fileInfo.source + " changed";');
+    const sourcePath = createTempFileWith('foo');
+    const emitter = worker([transformPath]);
+
+    emitter.send({files: [sourcePath]});
+    emitter.once('message', (data) => {
+      expect(data.status).toBe('ok');
+      expect(data.msg).toBe(sourcePath);
+      expect(getFileContent(sourcePath)).toBe('foo changed');
+      done();
+    });
+  });
+
+  describe('custom parser', () => {
+    function getTransformForParser(parser) {
+      return createTempFileWith(
+        `function transform(fileInfo, api) {
+          api.jscodeshift(fileInfo.source);
+          return "changed";
+         }
+         ${parser ? `transform.parser = '${parser}';` : ''}
+         module.exports = transform;
+        `
+      );
+    }
+    function getSourceFile() {
+      // This code cannot be parsed by Babel v5
+      return createTempFileWith(
+         'const x = (a: Object, b: string): void => {}'
+      );
+    }
+
+    it('errors if new flow type code is parsed with babel v5', done => {
+      const transformPath = createTransformWith(
+        'api.jscodeshift(fileInfo.source); return "changed";'
+      );
+      const sourcePath = getSourceFile();
+      const emitter = worker([transformPath]);
+
+      emitter.send({files: [sourcePath]});
+      emitter.once('message', (data) => {
+        expect(data.status).toBe('error');
+        expect(data.msg).toMatch('SyntaxError');
+        done();
+      });
+    });
+
+    it('uses babylon if configured as such', done => {
+      const transformPath = getTransformForParser('babylon');
+      const sourcePath = getSourceFile();
+      const emitter = worker([transformPath]);
+
+      emitter.send({files: [sourcePath]});
+      emitter.once('message', (data) => {
+        expect(data.status).toBe('ok');
+        expect(getFileContent(sourcePath)).toBe('changed');
+        done();
+      });
+    });
+
+    it('uses flow if configured as such', done => {
+      const transformPath = getTransformForParser('flow');
+      const sourcePath = getSourceFile();
+      const emitter = worker([transformPath]);
+
+      emitter.send({files: [sourcePath]});
+      emitter.once('message', (data) => {
+        expect(data.status).toBe('ok');
+        expect(getFileContent(sourcePath)).toBe('changed');
+        done();
+      });
+    });
+
+  });
+
+});

--- a/src/__tests__/core-test.js
+++ b/src/__tests__/core-test.js
@@ -8,6 +8,8 @@
  *
  */
 
+'use strict';
+
 /*global jest, describe, it, expect*/
 
 jest.autoMockOff();
@@ -54,24 +56,24 @@ describe('core API', function() {
     var source = '\nvar foo;\n';
     expect(core(source).toSource()).toEqual(source);
   });
-  
+
   it('plugins are called with core', function (done) {
     core.use(function (j) {
       expect(j).toBe(core);
       done();
     });
   });
-  
+
   it('plugins are only registered once', function () {
     var ct = 0;
-    
+
     function plugin() {
       ct++;
     }
-    
+
     core.use(plugin);
     core.use(plugin);
-    
+
     expect(ct).toBe(1);
   });
 

--- a/src/__tests__/matchNode-test.js
+++ b/src/__tests__/matchNode-test.js
@@ -9,6 +9,8 @@
 
 /*global jest, describe, it, expect, beforeEach*/
 
+'use strict';
+
 jest.autoMockOff();
 var matchNode = require('../matchNode');
 

--- a/src/collections/Node.js
+++ b/src/collections/Node.js
@@ -136,7 +136,7 @@ var mutationMethods = {
     return this.forEach(function(path, i) {
       var newNodes =
         (typeof nodes === 'function') ? nodes.call(path, path, i) : nodes;
-      path.replace(...toArray(newNodes));
+      path.replace.apply(path, toArray(newNodes));
     });
   },
 
@@ -150,7 +150,7 @@ var mutationMethods = {
     return this.forEach(function(path, i) {
       var newNodes =
         (typeof insert === 'function') ? insert.call(path, path, i) : insert;
-      path.insertBefore(...toArray(newNodes));
+      path.insertBefore.apply(path, toArray(newNodes));
     });
   },
 
@@ -164,7 +164,7 @@ var mutationMethods = {
     return this.forEach(function(path, i) {
       var newNodes =
         (typeof insert === 'function') ? insert.call(path, path, i) : insert;
-      path.insertAfter(...toArray(newNodes));
+      path.insertAfter.apply(path, toArray(newNodes));
     });
   },
 

--- a/src/collections/__tests__/JSXElement-test.js
+++ b/src/collections/__tests__/JSXElement-test.js
@@ -12,7 +12,7 @@
 
 jest.autoMockOff();
 
-var babel = require('babel-core');
+var babel = require('babelv5');
 
 describe('JSXCollection API', function() {
   var nodes;
@@ -40,7 +40,7 @@ describe('JSXCollection API', function() {
       '  </Child>',
       '  <Child id="2" foo="baz"/>',
       '</FooBar>'
-    ].join('\n'), {esprima: babel}).program];
+    ].join('\n'), {parser: babel}).program];
   });
 
   describe('Traversal', function() {

--- a/src/collections/__tests__/VariableDeclarator-test.js
+++ b/src/collections/__tests__/VariableDeclarator-test.js
@@ -12,7 +12,7 @@
 
 jest.autoMockOff();
 
-var babel = require('babel-core');
+var babel = require('babelv5');
 var recast = require('recast');
 var types = recast.types.namedTypes;
 var b = recast.types.builders;
@@ -43,7 +43,7 @@ describe('VariableDeclarators', function() {
       'foo.bar();',
       'foo[bar]();',
       'bar.foo();'
-    ].join('\n'), {esprima: babel}).program];
+    ].join('\n'), {parser: babel}).program];
   });
 
   describe('Traversal', function() {

--- a/src/getParser.js
+++ b/src/getParser.js
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (c) 2015-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+'use strict';
+
+module.exports = function getParser(parserName) {
+  switch (parserName) {
+    case 'babylon':
+      return require('../parser/babylon');
+    case 'flow':
+      return require('flow-parser');
+    case 'babel':
+    default:
+      return require('babelv5');
+  }
+};

--- a/src/template.js
+++ b/src/template.js
@@ -1,100 +1,144 @@
-let babel = require('babel-core');
+/*
+ *  Copyright (c) 2015-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+'use strict';
+
+const recast = require('recast');
+
+const builders = recast.types.builders;
+const types = recast.types.namedTypes;
 
 function splice(arr, element, replacement) {
-  arr.splice(arr.indexOf(element), 1, ...replacement);
+  arr.splice.apply(arr, [arr.indexOf(element), 1].concat(replacement));
 }
 
-function getPlugin(varName, nodes) {
+function cleanLocation(node) {
+  delete node.start;
+  delete node.end;
+  delete node.loc;
+  return node;
+}
+
+function ensureStatement(node) {
+  return types.Statement.check(node) ?
+    // Removing the location information seems to ensure that the node is
+    // correctly reprinted with a trailing semicolon
+    cleanLocation(node) :
+    builders.expressionStatement(node);
+}
+
+function getVistor(varName, nodes) {
   let counter = 0;
+  return {
+    visitIdentifier: function(path) {
+      this.traverse(path);
+      const node = path.node;
+      const parent = path.parent.node;
 
-  return function({Plugin, types: t}) {
-    return new Plugin('template', {
-      visitor: {
-        Identifier: {
-          exit: function(node, parent) {
-            if (node.name !== varName) {
-              return node;
-            }
-
-            let replacement = nodes[counter++];
-            if (Array.isArray(replacement)) {
-              // check whether we can explode arrays here
-              if (t.isFunction(parent) && parent.params.indexOf(node) > -1) {
-                // function foo(${bar}) {}
-                splice(parent.params, node, replacement);
-              } else if (t.isVariableDeclarator(parent)) {
-                // var foo = ${bar}, baz = 42;
-                splice(
-                  this.parentPath.parentPath.node.declarations,
-                  parent,
-                  replacement
-                );
-              } else if (t.isArrayExpression(parent)) {
-                // var foo = [${bar}, baz];
-                splice(parent.elements, node, replacement);
-              } else if (t.isProperty(parent) && parent.shorthand) {
-                // var foo = {${bar}, baz: 42};
-                splice(
-                  this.parentPath.parentPath.node.properties,
-                  parent,
-                  replacement
-                );
-              } else if (t.isCallExpression(parent) &&
-                  parent.arguments.indexOf(node) > -1) {
-                // foo(${bar}, baz)
-                splice(parent.arguments, node, replacement);
-              } else if (t.isExpressionStatement(parent)) {
-                this.parentPath.replaceWithMultiple(replacement);
-              } else {
-                this.replaceWithMultiple(replacement);
-              }
-            } else if (t.isExpressionStatement(parent)) {
-              this.parentPath.replaceWith(replacement);
-            } else {
-              return replacement;
-            }
-          }
-        }
+      // If this identifier is not one of our generated ones, do nothing
+      if (node.name !== varName) {
+        return;
       }
-    });
+
+      let replacement = nodes[counter++];
+
+      // If the replacement is an array, we need to explode the nodes in context
+      if (Array.isArray(replacement)) {
+
+        if (types.Function.check(parent) &&
+            parent.params.indexOf(node) > -1) {
+          // Function parameters: function foo(${bar}) {}
+          splice(parent.params, node, replacement);
+        } else if (types.VariableDeclarator.check(parent)) {
+          // Variable declarations: var foo = ${bar}, baz = 42;
+          splice(
+            path.parent.parent.node.declarations,
+            parent,
+            replacement
+          );
+        } else if (types.ArrayExpression.check(parent)) {
+          // Arrays: var foo = [${bar}, baz];
+          splice(parent.elements, node, replacement);
+        } else if (types.Property.check(parent) && parent.shorthand) {
+          // Objects: var foo = {${bar}, baz: 42};
+          splice(
+            path.parent.parent.node.properties,
+            parent,
+            replacement
+          );
+        } else if (types.CallExpression.check(parent) &&
+            parent.arguments.indexOf(node) > -1) {
+          // Function call arguments: foo(${bar}, baz)
+          splice(parent.arguments, node, replacement);
+        } else if (types.ExpressionStatement.check(parent)) {
+          // Generic sequence of statements: { ${foo}; bar; }
+          path.parent.replace.apply(
+            path.parent,
+            replacement.map(ensureStatement)
+          );
+        } else {
+          // Every else, let recast take care of it
+          path.replace.apply(path, replacement);
+        }
+      } else if (types.ExpressionStatement.check(parent)) {
+        path.parent.replace(ensureStatement(replacement));
+      } else {
+        path.replace(replacement);
+      }
+    }
   };
 }
 
-function replaceNodes(src, varName, nodes) {
-  return babel.transform(
-    src,
-    {
-      plugins: [getPlugin(varName, nodes)],
-      whitelist: [],
-      code: false,
-    }
-  ).ast;
+function replaceNodes(src, varName, nodes, parser) {
+  const ast = recast.parse(src, {parser});
+  recast.visit(ast, getVistor(varName, nodes));
+  return ast;
 }
 
 function getRandomVarName() {
   return `$jscodeshift${Math.floor(Math.random() * 1000)}$`;
 }
 
-export function statements(template, ...nodes) {
-  template = [...template];
-  let varName = getRandomVarName();
-  let src = template.join(varName);
-  return replaceNodes(src, varName, nodes).program.body;
-}
 
-export function statement(template, ...nodes) {
-  return statements(template, ...nodes)[0];
-}
-
-export function expression(template, ...nodes) {
-  // wrap code in `(...)` to force evaluation as expression
-  template = [...template];
-  if (template.length > 1) {
-    template[0] = '(' + template[0];
-    template[template.length - 1] += ')';
-  } else if (template.length === 0) {
-    template[0] = '(' + template[0] + ')';
+module.exports = function withParser(parser) {
+  function statements(template/*, ...nodes*/) {
+    template = Array.from(template);
+    let varName = getRandomVarName();
+    let src = template.join(varName);
+    return replaceNodes(
+      src,
+      varName,
+      Array.from(arguments).slice(1),
+      parser
+    ).program.body;
   }
 
-  return statement(template, ...nodes).expression;
+  function statement(/*template, ...nodes*/) {
+    return statements.apply(null, arguments)[0];
+  }
+
+  function expression(template/*, ...nodes*/) {
+    // wrap code in `(...)` to force evaluation as expression
+    template = Array.from(template);
+    if (template.length > 1) {
+      template[0] = '(' + template[0];
+      template[template.length - 1] += ')';
+    } else if (template.length === 0) {
+      template[0] = '(' + template[0] + ')';
+    }
+
+    return statement.apply(
+      null,
+      [template].concat(Array.from(arguments).slice(1))
+    ).expression;
+  }
+
+  return {statements, statement, expression};
 }

--- a/src/testUtils.js
+++ b/src/testUtils.js
@@ -7,10 +7,12 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* global expect, define, it */
+/* global expect, describe, it */
 
-import fs from 'fs';
-import path from 'path';
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
 
 /**
  * Utility function to run a jscodeshift script within a unit test. This makes
@@ -31,7 +33,7 @@ import path from 'path';
  * - Test data should be located in a directory called __testfixtures__
  *   alongside the transform and __tests__ directory.
  */
-export function runTest(dirName, transformName, options, testFilePrefix) {
+function runTest(dirName, transformName, options, testFilePrefix) {
   if (!testFilePrefix) {
     testFilePrefix = transformName;
   }
@@ -61,12 +63,13 @@ export function runTest(dirName, transformName, options, testFilePrefix) {
   );
   expect((output || '').trim()).toEqual(expectedOutput.trim());
 }
+exports.runTest = runTest;
 
 /**
  * Handles some boilerplate around defining a simple jest/Jasmine test for a
  * jscodeshift transform.
  */
-export function defineTest(dirName, transformName, options, testFilePrefix) {
+function defineTest(dirName, transformName, options, testFilePrefix) {
   var testName = testFilePrefix
     ? `transforms correctly using "${testFilePrefix}" data`
     : 'transforms correctly';
@@ -76,3 +79,4 @@ export function defineTest(dirName, transformName, options, testFilePrefix) {
     });
   });
 }
+exports.defineTest = defineTest;

--- a/utils/requirePackage.js
+++ b/utils/requirePackage.js
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2015-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+'use strict';
+
+const path = require('path');
+
+module.exports = function requirePackage(name) {
+	const entry = require.resolve(name);
+  let dir = path.dirname(entry);
+  while (dir !== '/') {
+    try {
+      const pkg = require(path.join(dir, 'package.json'));
+      return pkg.name === name ? pkg : {};
+    } catch(error) {} // eslint-disable-line no-empty
+    dir = path.dirname(dir);
+  }
+  return {};
+}

--- a/utils/testUtils.js
+++ b/utils/testUtils.js
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+'use strict';
+
+const fs = require('fs');
+const mkdirp = require('mkdirp');
+const path = require('path');
+const temp = require('temp');
+
+function renameFileTo(oldPath, newFilename) {
+  const projectPath = path.dirname(oldPath);
+  const newPath = path.join(projectPath, newFilename);
+  mkdirp.sync(path.dirname(newPath));
+  fs.renameSync(oldPath, newPath);
+  return newPath;
+}
+
+function createTempFileWith(content, filename) {
+  const info = temp.openSync();
+  let filePath = info.path;
+  fs.writeSync(info.fd, content);
+  fs.closeSync(info.fd);
+  if (filename) {
+    filePath = renameFileTo(filePath, filename);
+  }
+  return filePath;
+}
+exports.createTempFileWith = createTempFileWith;
+
+function createTransformWith(content, fileName) {
+  return createTempFileWith(
+    'module.exports = function(fileInfo, api, options) { ' + content + ' }',
+    fileName
+  );
+}
+exports.createTransformWith = createTransformWith;
+
+function getFileContent(filePath) {
+  return fs.readFileSync(filePath).toString();
+}
+exports.getFileContent = getFileContent;


### PR DESCRIPTION
jscodeshift uses Babel v5 to parse source files. Since Babel v5 doesn't get updated anymore, jscodeshift is unable to parse files that contain more modern flow type annotation.

To solve this, jscodeshift now supports three parsers: Babel v5, babylon and flow. The parser to use can be chosen by either

  - passing the command line option `parser`: `--parser=babelv5`,
    `--parser=babylon`, `--parser=flow`.
  - having the transform file export `parser`, with either the values
    `"babelv5"`, `"babylon"` or `"flow` to choose one of the built-int
    parsers, or export a parser object (e.g. `exports.parser = require('flow=parser'`)

    This allows transform to specify their own parser (as long as it is compatible with ESTree / recast), making them a bit more independent from jscodeshifts internals.

In addition to this change, `jscodeshift` now accepts a second argument, `options` which is directly parsed passed to `recast.parse`. So if you use `jscodeshift` programmatically , you can now pass your own parser with

```
jscodeshift(source, {parser: require('myParser')})
```

**Note:** This is *not* a breaking change. Babel v5 still stays the default parser, but we will likely use another parser (babylon or flow) as default in the future.

---

As another effect, I'm removing jscodeshift's own build step. Node v4 almost supports everything we want, I just removed the few occurrences of spread and destructuring. Using babel as part of the tool itself and as build tool is a but confusing.