### PR TITLE
Upgrade lodash to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "colors": "^1.1.2",
     "es6-promise": "^3.0.0",
     "flow-parser": "^0.*",
-    "lodash": "^3.5.0",
+    "lodash": "^4.13.1",
     "micromatch": "^2.3.7",
     "node-dir": "0.1.8",
     "nomnom": "^1.8.1",


### PR DESCRIPTION
lodash v3 has an issue that causes `TypeError: Cannot read property 'prototype' of undefined` when we set Jest's `testEnvironment` to `node`. This has been fixed in v4 (lodash/lodash#223).

Thanks for reviewing! cc @cpojer 