### PR TITLE
Include stats and timing information in node API

### DIFF
--- a/src/Runner.js
+++ b/src/Runner.js
@@ -259,19 +259,23 @@ function run(transformFile, paths, options) {
       })
       .then(pendingWorkers =>
         Promise.all(pendingWorkers).then(() => {
+          const endTime = process.hrtime(startTime);
+          const timeElapsed = (endTime[0] + endTime[1]/1e9).toFixed(3);
           if (!options.silent) {
-            const endTime = process.hrtime(startTime);
             process.stdout.write('All done. \n');
             showFileStats(fileCounters);
             showStats(statsCounter);
             process.stdout.write(
-              'Time elapsed: ' + (endTime[0] + endTime[1]/1e9).toFixed(3) + 'seconds \n'
+              'Time elapsed: ' + timeElapsed + 'seconds \n'
             );
           }
           if (usedRemoteScript) {
             temp.cleanupSync();
           }
-          return fileCounters;
+          return Object.assign({
+            stats: statsCounter,
+            timeElapsed: timeElapsed
+          }, fileCounters);
         })
       );
   }


### PR DESCRIPTION
This allows for jscodeshift to be used first class for doing simple static analysis reporting.

For example I am using this change to detect and print out `process.env[VARIABLE]`s accessed and track our analytics calls to automate documenting what has been implemented and what still needs to be implemented.