### PR TITLE
Add eslint and babel-eslint to devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "temp": "^0.8.1"
   },
   "devDependencies": {
+    "babel-eslint": "^6.1.2",
+    "eslint": "^3.1.1",
     "jest-cli": "^12.0.0",
     "mkdirp": "^0.5.1"
   },


### PR DESCRIPTION
Thanks for including a lint config!

I have my editor setup to always use a packages local copy of `ESLint` to prevent possible version /config problems. Noticed it failing out when working on #126.

Any problems with adding them? I can work-around it if not.