### PR TITLE
Custom cli helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,29 @@ This will run two tests: One for `__testfixtures__/FirstFixture.input.js` and on
 
 A simple example is bundled in the [sample directory](sample).
 
+### Custom CLI helper for codemod collections
+In collections of codemods one might want to make it easy to use the codemods through npm.
+The idea behind the custom CLI helper is to make it easy for codemod collection authors to
+create CLIs for their collections. It provides tailored responses to `--help` and `--version`.
+
+#### Example usage
+The code below can be used as an example for creating bin files for a custom CLI.
+
+```js
+#!/usr/bin/env node
+
+const resolve = require('path').resolve;
+const cli = require('jscodeshift').cli;
+
+cli({
+  name: 'Custom CLI',
+  packageVersion: '2.3.0',
+  resolve(name) {
+    // return absolute path to the transform with a given name.
+    return resolve(__dirname, `./transforms/${name}.js`);
+  },
+});
+```
 
 ### Example Codemods
 

--- a/README.md
+++ b/README.md
@@ -372,10 +372,11 @@ The code below can be used as an example for creating bin files for a custom CLI
 
 const resolve = require('path').resolve;
 const cli = require('jscodeshift').cli;
+const pkg = require('./package.json');
 
 cli({
   name: 'Custom CLI',
-  packageVersion: '2.3.0',
+  packageVersion: pkg.version,
   resolve(name) {
     // return absolute path to the transform with a given name.
     return resolve(__dirname, `./transforms/${name}.js`);

--- a/bin/jscodeshift.sh
+++ b/bin/jscodeshift.sh
@@ -15,100 +15,14 @@ const Runner = require('../dist/Runner.js');
 
 const path = require('path');
 const pkg = require('../package.json');
+const cliOptions = require('../src/cli').options;
 const opts = require('nomnom')
   .script('jscodeshift')
-  .options({
-    path: {
-      position: 0,
-      help: 'Files or directory to transform',
-      list: true,
-      metavar: 'FILE',
-      required: true
-    },
-    transform: {
-      abbr: 't',
-      default: './transform.js',
-      help: 'Path to the transform file. Can be either a local path or url',
-      metavar: 'FILE'
-    },
-    cpus: {
-      abbr: 'c',
-      help: '(all by default) Determines the number of processes started.'
-    },
-    verbose: {
-      abbr: 'v',
-      choices: [0, 1, 2],
-      default: 0,
-      help: 'Show more information about the transform process'
-    },
-    dry: {
-      abbr: 'd',
-      flag: true,
-      help: 'Dry run (no changes are made to files)'
-    },
-    print: {
-      abbr: 'p',
-      flag: true,
-      help: 'Print output, useful for development'
-    },
-    babel: {
-      flag: true,
-      default: true,
-      help: 'Apply Babel to transform files'
-    },
-    extensions: {
-      default: 'js',
-      help: 'File extensions the transform file should be applied to'
-    },
-    ignorePattern: {
-      full: 'ignore-pattern',
-      list: true,
-      help: 'Ignore files that match a provided glob expression'
-    },
-    ignoreConfig: {
-      full: 'ignore-config',
-      list: true,
-      help: 'Ignore files if they match patterns sourced from a configuration file (e.g., a .gitignore)',
-      metavar: 'FILE'
-    },
-    runInBand: {
-      flag: true,
-      default: false,
-      full: 'run-in-band',
-      help: 'Run serially in the current process'
-    },
-    silent: {
-      abbr: 's',
-      flag: true,
-      default: false,
-      full: 'silent',
-      help: 'No output'
-    },
-    parser: {
-      choices: ['babel', 'babylon', 'flow'],
-      default: 'babel',
-      full: 'parser',
-      help: 'The parser to use for parsing your source files (babel | babylon | flow)'
-    },
-    version: {
-      flag: true,
-      help: 'print version and exit',
-      callback: function() {
-        const requirePackage = require('../utils/requirePackage');
-        return [
-          `jscodeshift: ${pkg.version}`,
-          ` - babel: ${require('babel-core').version}`,
-          ` - babylon: ${requirePackage('babylon').version}`,
-          ` - flow: ${requirePackage('flow-parser').version}`,
-          ` - recast: ${requirePackage('recast').version}`,
-        ].join('\n');
-      },
-    },
-  })
+  .options(cliOptions)
   .parse();
 
 Runner.run(
-  /^https?/.test(opts.transform) ? opts.transform : path.resolve(opts.transform), 
+  /^https?/.test(opts.transform) ? opts.transform : path.resolve(opts.transform),
   opts.path,
   opts
 );

--- a/bin/jscodeshift.sh
+++ b/bin/jscodeshift.sh
@@ -15,7 +15,7 @@ const Runner = require('../dist/Runner.js');
 
 const path = require('path');
 const pkg = require('../package.json');
-const cliOptions = require('../src/cli').options;
+const cliOptions = require('../src/cli').defaults;
 const opts = require('nomnom')
   .script('jscodeshift')
   .options(cliOptions)

--- a/sample/noop.js
+++ b/sample/noop.js
@@ -1,0 +1,16 @@
+/**
+ *  Copyright (c) 2016-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/**
+ * This is an empty jscodeshift transform. It does nothing to the code passed to it.
+ */
+
+module.exports = function transformer(file) {
+  return file.source;
+}

--- a/src/__tests__/custom-cli
+++ b/src/__tests__/custom-cli
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+
+const resolve = require('path').resolve;
+const cli = require('../cli').cliGenerator;
+
+cli({
+  name: 'Custom CLI',
+  packageVersion: '2.3.0',
+  resolve(name) {
+    return resolve(__dirname, `../../sample/${name}.js`);
+  },
+});

--- a/src/__tests__/custom-cli-test.js
+++ b/src/__tests__/custom-cli-test.js
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2015-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+'use strict';
+
+/*global jest, describe, it, expect*/
+
+jest.autoMockOff();
+
+const cp = require('child_process');
+const resolve = require('path').resolve;
+const cli = resolve(__dirname, 'custom-cli');
+
+function execFile(file, args) {
+  return new Promise((resolve, reject) => {
+    cp.execFile(file, args, (error, output) => {
+      if (error) return reject(error);
+
+      resolve(output);
+    });
+  });
+}
+
+describe('Custom CLI', function() {
+  it('should show help when --help is passed', function() {
+    return execFile(cli, ['--help'])
+      .then(function (result) {
+        expect(result).toContain('Usage: Custom CLI <transform> <path>');
+      })
+  });
+
+  it('should resolve transform', function() {
+    return execFile(cli, ['noop', resolve(__dirname, 'custom-cli-test.js')])
+      .then(function (result) {
+        expect(result).toContain('Using transform noop');
+        expect(result).toContain('Processing 1 files...');
+      })
+  });
+
+  it('should fail when transform is not resolved', function() {
+    let catched = false;
+    return execFile(cli, ['non-existing-codemod', resolve(__dirname, 'custom-cli-test.js')])
+      .catch(function (error) {
+        catched = true;
+        expect(error.toString()).toContain('The transform non-existing-codemod does not exist.')
+      })
+      .then(() => {
+        expect(catched).toBe(true);
+      });
+  });
+});

--- a/src/__tests__/custom-cli-test.js
+++ b/src/__tests__/custom-cli-test.js
@@ -47,14 +47,14 @@ describe('Custom CLI', function() {
   });
 
   it('should fail when transform is not resolved', function() {
-    let catched = false;
+    let caught = false;
     return execFile(cli, ['non-existing-codemod', resolve(__dirname, 'custom-cli-test.js')])
       .catch(function (error) {
-        catched = true;
+        caught = true;
         expect(error.toString()).toContain('The transform non-existing-codemod does not exist.')
       })
       .then(() => {
-        expect(catched).toBe(true);
+        expect(caught).toBe(true);
       });
   });
 });

--- a/src/__tests__/custom-cli-test.js
+++ b/src/__tests__/custom-cli-test.js
@@ -29,6 +29,8 @@ function execFile(file, args) {
 }
 
 describe('Custom CLI', function() {
+  jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000;
+
   it('should show help when --help is passed', function() {
     return execFile(cli, ['--help'])
       .then(function (result) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -10,7 +10,6 @@
 
  /* eslint-disable no-console */
 
-const _ = require('lodash');
 const fs = require('fs');
 
 const pkg = require('../package.json');
@@ -145,7 +144,7 @@ function cliGenerator(cliOptions) {
 
   const args = require('nomnom')
     .script(name)
-    .options(_.assign({}, defaults, {version, transform, path}))
+    .options(Object.assign({}, defaults, {version, transform, path}))
     .parse();
 
   const transformerPath = resolve(args.transform);
@@ -160,7 +159,7 @@ function cliGenerator(cliOptions) {
     Runner.run(
       transformerPath,
       args.path,
-      _.assign({}, options, args)
+      Object.assign({}, options, args)
     );
   });
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -8,7 +8,10 @@
  *
  */
 
+ /* eslint-disable no-console */
+
 const _ = require('lodash');
+const fs = require('fs');
 
 const pkg = require('../package.json');
 const Runner = require('../dist/Runner.js');
@@ -145,11 +148,21 @@ function cliGenerator(cliOptions) {
     .options(_.assign({}, defaults, {version, transform, path}))
     .parse();
 
-  Runner.run(
-    resolve(args.transform),
-    args.path,
-    _.assign({}, options, args)
-  );
+  const transformerPath = resolve(args.transform);
+  fs.stat(transformerPath, function (error) {
+    if (error) {
+      console.error(`The transform ${args.transform} does not exist.`);
+      process.exit(1);
+    }
+
+    console.log(`Using transform ${args.transform}.`);
+
+    Runner.run(
+      transformerPath,
+      args.path,
+      _.assign({}, options, args)
+    );
+  });
 }
 
 module.exports = {defaults, cliGenerator};

--- a/src/cli.js
+++ b/src/cli.js
@@ -8,95 +8,148 @@
  *
  */
 
-const pkg = require('../package.json');
+const _ = require('lodash');
 
-const options = {
-    path: {
-      position: 0,
-      help: 'Files or directory to transform',
-      list: true,
-      metavar: 'FILE',
-      required: true
+const pkg = require('../package.json');
+const Runner = require('../dist/Runner.js');
+
+function dependencyVersions() {
+  const requirePackage = require('../utils/requirePackage');
+  return [
+    ` - babel: ${require('babel-core').version}`,
+    ` - babylon: ${requirePackage('babylon').version}`,
+    ` - flow: ${requirePackage('flow-parser').version}`,
+    ` - recast: ${requirePackage('recast').version}`,
+  ].join('\n');
+}
+
+const defaults = {
+  path: {
+    position: 0,
+    help: 'Files or directory to transform',
+    list: true,
+    metavar: 'FILE',
+    required: true
+  },
+  transform: {
+    abbr: 't',
+    default: './transform.js',
+    help: 'Path to the transform file. Can be either a local path or url',
+    metavar: 'FILE'
+  },
+  cpus: {
+    abbr: 'c',
+    help: '(all by default) Determines the number of processes started.'
+  },
+  verbose: {
+    abbr: 'v',
+    choices: [0, 1, 2],
+    default: 0,
+    help: 'Show more information about the transform process'
+  },
+  dry: {
+    abbr: 'd',
+    flag: true,
+    help: 'Dry run (no changes are made to files)'
+  },
+  print: {
+    abbr: 'p',
+    flag: true,
+    help: 'Print output, useful for development'
+  },
+  babel: {
+    flag: true,
+    default: true,
+    help: 'Apply Babel to transform files'
+  },
+  extensions: {
+    default: 'js',
+    help: 'File extensions the transform file should be applied to'
+  },
+  ignorePattern: {
+    full: 'ignore-pattern',
+    list: true,
+    help: 'Ignore files that match a provided glob expression'
+  },
+  ignoreConfig: {
+    full: 'ignore-config',
+    list: true,
+    help: 'Ignore files if they match patterns sourced from a configuration file (e.g., a .gitignore)',
+    metavar: 'FILE'
+  },
+  runInBand: {
+    flag: true,
+    default: false,
+    full: 'run-in-band',
+    help: 'Run serially in the current process'
+  },
+  silent: {
+    abbr: 's',
+    flag: true,
+    default: false,
+    full: 'silent',
+    help: 'No output'
+  },
+  parser: {
+    choices: ['babel', 'babylon', 'flow'],
+    default: 'babel',
+    full: 'parser',
+    help: 'The parser to use for parsing your source files (babel | babylon | flow)'
+  },
+  version: {
+    flag: true,
+    help: 'print version and exit',
+    callback: function() {
+      return [
+        `jscodeshift: ${pkg.version}`,
+        dependencyVersions(),
+      ].join('\n');
     },
-    transform: {
-      abbr: 't',
-      default: './transform.js',
-      help: 'Path to the transform file. Can be either a local path or url',
-      metavar: 'FILE'
+  },
+};
+
+function cliGenerator(cliOptions) {
+  const name = cliOptions.name;
+  const packageVersion = cliOptions.packageVersion;
+  const resolve = cliOptions.resolve;
+  const options = cliOptions.options;
+
+  const version = {
+    flag: true,
+    help: 'print version and exit',
+    callback: function() {
+      return [
+        `${name}: ${packageVersion}`,
+        ` - jscodeshift: ${pkg.version}`,
+        dependencyVersions(),
+      ].join('\n');
     },
-    cpus: {
-      abbr: 'c',
-      help: '(all by default) Determines the number of processes started.'
-    },
-    verbose: {
-      abbr: 'v',
-      choices: [0, 1, 2],
-      default: 0,
-      help: 'Show more information about the transform process'
-    },
-    dry: {
-      abbr: 'd',
-      flag: true,
-      help: 'Dry run (no changes are made to files)'
-    },
-    print: {
-      abbr: 'p',
-      flag: true,
-      help: 'Print output, useful for development'
-    },
-    babel: {
-      flag: true,
-      default: true,
-      help: 'Apply Babel to transform files'
-    },
-    extensions: {
-      default: 'js',
-      help: 'File extensions the transform file should be applied to'
-    },
-    ignorePattern: {
-      full: 'ignore-pattern',
-      list: true,
-      help: 'Ignore files that match a provided glob expression'
-    },
-    ignoreConfig: {
-      full: 'ignore-config',
-      list: true,
-      help: 'Ignore files if they match patterns sourced from a configuration file (e.g., a .gitignore)',
-      metavar: 'FILE'
-    },
-    runInBand: {
-      flag: true,
-      default: false,
-      full: 'run-in-band',
-      help: 'Run serially in the current process'
-    },
-    silent: {
-      abbr: 's',
-      flag: true,
-      default: false,
-      full: 'silent',
-      help: 'No output'
-    },
-    parser: {
-      choices: ['babel', 'babylon', 'flow'],
-      default: 'babel',
-      full: 'parser',
-      help: 'The parser to use for parsing your source files (babel | babylon | flow)'
-    },
-    version: {
-      flag: true,
-      help: 'print version and exit',
-      callback: function() {
-        const requirePackage = require('../utils/requirePackage');
-        return [
-          `jscodeshift: ${pkg.version}`,
-          ` - babel: ${require('babel-core').version}`,
-          ` - babylon: ${requirePackage('babylon').version}`,
-          ` - flow: ${requirePackage('flow-parser').version}`,
-          ` - recast: ${requirePackage('recast').version}`,
-        ].join('\n');
-      },
-    },
+  };
+
+  const transform = {
+    position: 0,
+    help: 'The transformer to use',
+    required: true,
+  };
+
+  const path = {
+    position: 1,
+    help: 'Files or directory to transform',
+    list: true,
+    metavar: 'FILE',
+    required: true,
   }
 
-module.exports = {options};
+  const args = require('nomnom')
+    .script(name)
+    .options(_.assign({}, defaults, {version, transform, path}))
+    .parse();
+
+  Runner.run(
+    resolve(args.transform),
+    args.path,
+    _.assign({}, options, args)
+  );
+}
+
+module.exports = {defaults, cliGenerator};

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,0 +1,102 @@
+/*
+ *  Copyright (c) 2015-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+const pkg = require('../package.json');
+
+const options = {
+    path: {
+      position: 0,
+      help: 'Files or directory to transform',
+      list: true,
+      metavar: 'FILE',
+      required: true
+    },
+    transform: {
+      abbr: 't',
+      default: './transform.js',
+      help: 'Path to the transform file. Can be either a local path or url',
+      metavar: 'FILE'
+    },
+    cpus: {
+      abbr: 'c',
+      help: '(all by default) Determines the number of processes started.'
+    },
+    verbose: {
+      abbr: 'v',
+      choices: [0, 1, 2],
+      default: 0,
+      help: 'Show more information about the transform process'
+    },
+    dry: {
+      abbr: 'd',
+      flag: true,
+      help: 'Dry run (no changes are made to files)'
+    },
+    print: {
+      abbr: 'p',
+      flag: true,
+      help: 'Print output, useful for development'
+    },
+    babel: {
+      flag: true,
+      default: true,
+      help: 'Apply Babel to transform files'
+    },
+    extensions: {
+      default: 'js',
+      help: 'File extensions the transform file should be applied to'
+    },
+    ignorePattern: {
+      full: 'ignore-pattern',
+      list: true,
+      help: 'Ignore files that match a provided glob expression'
+    },
+    ignoreConfig: {
+      full: 'ignore-config',
+      list: true,
+      help: 'Ignore files if they match patterns sourced from a configuration file (e.g., a .gitignore)',
+      metavar: 'FILE'
+    },
+    runInBand: {
+      flag: true,
+      default: false,
+      full: 'run-in-band',
+      help: 'Run serially in the current process'
+    },
+    silent: {
+      abbr: 's',
+      flag: true,
+      default: false,
+      full: 'silent',
+      help: 'No output'
+    },
+    parser: {
+      choices: ['babel', 'babylon', 'flow'],
+      default: 'babel',
+      full: 'parser',
+      help: 'The parser to use for parsing your source files (babel | babylon | flow)'
+    },
+    version: {
+      flag: true,
+      help: 'print version and exit',
+      callback: function() {
+        const requirePackage = require('../utils/requirePackage');
+        return [
+          `jscodeshift: ${pkg.version}`,
+          ` - babel: ${require('babel-core').version}`,
+          ` - babylon: ${requirePackage('babylon').version}`,
+          ` - flow: ${requirePackage('flow-parser').version}`,
+          ` - recast: ${requirePackage('recast').version}`,
+        ].join('\n');
+      },
+    },
+  }
+
+module.exports = {options};

--- a/src/core.js
+++ b/src/core.js
@@ -16,6 +16,7 @@ var getParser = require('./getParser');
 var matchNode = require('./matchNode');
 var recast = require('recast');
 var template = require('./template');
+var cliGenerator = require('./cli').cliGenerator;
 
 var Node = recast.types.namedTypes.Node;
 var NodePath = recast.types.NodePath;
@@ -147,6 +148,7 @@ function enrichCore(core, parser) {
   core.types = recast.types;
   core.match = match;
   core.template = template(parser);
+  core.cli = cliGenerator;
 
   // add mappings and filters to function
   core.filters = {};


### PR DESCRIPTION
Makes it possible to create cli interfaces for codemod collections. See #132 
### Example usage

``` javascript
#!/usr/bin/env node

const resolve = require('path').resolve;
const cli = require('jscodeshift').cli;

cli({
  name: 'Custom CLI',
  packageVersion: '2.3.0',
  resolve(name) {
    return resolve(__dirname, `./transforms/${name}.js`);
  },
});
```
#### `--help` output

```
Usage: Custom CLI <transform> <path>... [options]

transform     The transformer to use
path          Files or directory to transform

Options:
   -c, --cpus             (all by default) Determines the number of processes started.
   -v, --verbose          Show more information about the transform process  [0]
   -d, --dry              Dry run (no changes are made to files)
   -p, --print            Print output, useful for development
   --babel                Apply Babel to transform files  [true]
   --extensions           File extensions the transform file should be applied to  [js]
   --ignore-pattern       Ignore files that match a provided glob expression
   --ignore-config FILE   Ignore files if they match patterns sourced from a configuration file (e.g., a .gitignore)
   --run-in-band          Run serially in the current process  [false]
   -s, --silent           No output  [false]
   --parser               The parser to use for parsing your source files (babel | babylon | flow)  [babel]
   --version              print version and exit
```
#### `--version` ouput

```
Custom CLI: 2.3.0
 - jscodeshift: 0.3.26
 - babel: 5.8.38
 - babylon: 6.8.4
 - flow: 0.28.0
 - recast: 0.11.10
```

Fixes #132
