### PR TITLE
Start setting up auto-generated documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "build": "cp -R src/ dist/",
     "test": "jest --bail",
-    "prepublish": "npm run build && npm run test"
+    "prepublish": "npm run build && npm run test",
+    "docs": "rm -rf docs && jsdoc -d docs -R README.md src/collections/* src/core.js src/Collection.js"
   },
   "bin": {
     "jscodeshift": "./bin/jscodeshift.sh"
@@ -47,6 +48,7 @@
     "babel-eslint": "^6.1.2",
     "eslint": "^3.1.1",
     "jest-cli": "^12.0.0",
+    "jsdoc": "^3.4.0",
     "mkdirp": "^0.5.1"
   },
   "jest": {

--- a/src/collections/JSXElement.js
+++ b/src/collections/JSXElement.js
@@ -25,6 +25,7 @@ var Literal = types.Literal;
 
 /**
  * Contains filter methods and mutation methods for processing JSXElements.
+ * @mixin
  */
 var globalMethods = {
   /**
@@ -124,6 +125,9 @@ var filterMethods = {
   }
 };
 
+/**
+* @mixin
+*/
 var traversalMethods = {
 
   /**

--- a/src/collections/Node.js
+++ b/src/collections/Node.js
@@ -19,6 +19,9 @@ var recast = require('recast');
 var Node = recast.types.namedTypes.Node;
 var types = recast.types.namedTypes;
 
+/**
+* @mixin
+*/
 var traversalMethods = {
 
   /**
@@ -123,6 +126,9 @@ function toArray(value) {
   return Array.isArray(value) ? value : [value];
 }
 
+/**
+* @mixin
+*/
 var mutationMethods = {
   /**
    * Simply replaces the selected nodes with the provided node. If a function

--- a/src/collections/VariableDeclarator.js
+++ b/src/collections/VariableDeclarator.js
@@ -22,6 +22,9 @@ var types = recast.types.namedTypes;
 
 var VariableDeclarator = recast.types.namedTypes.VariableDeclarator;
 
+/**
+* @mixin
+*/
 var globalMethods = {
   /**
    * Finds all variable declarators, optionally filtered by name.
@@ -34,7 +37,6 @@ var globalMethods = {
     return this.find(VariableDeclarator, filter);
   }
 };
-
 
 var filterMethods = {
   /**
@@ -64,6 +66,9 @@ var filterMethods = {
   }
 };
 
+/**
+* @mixin
+*/
 var transformMethods = {
   /**
    * Renames a variable and all its occurrences.

--- a/src/core.js
+++ b/src/core.js
@@ -36,6 +36,7 @@ for (var name in collections) {
  * - an array of nodes
  * - an array of node paths
  *
+ * @exports jscodeshift
  * @param {Node|NodePath|Array|string} source
  * @param {Object} options Options to pass to Recast when passing source code
  * @return {Collection}
@@ -50,6 +51,7 @@ function core(source, options) {
  * Returns a collection from a node, node path, array of nodes or array of node
  * paths.
  *
+ * @ignore
  * @param {Node|NodePath|Array} source
  * @return {Collection}
  */
@@ -84,7 +86,8 @@ function fromSource(source, options) {
 
 /**
  * Utility function to match a node against a pattern.
- *
+ * @augments core
+ * @static
  * @param {Node|NodePath|Object} path
  * @parma {Object} filter
  * @return boolean
@@ -109,6 +112,8 @@ var plugins = [];
  * They should extend jscodeshift by calling `registerMethods`, etc.
  * This method guards against repeated registrations (the plugin callback will only be called once).
  *
+ * @augments core
+ * @static
  * @param {Function} plugin
  */
 function use(plugin) {
@@ -121,6 +126,9 @@ function use(plugin) {
 /**
  * Returns a version of the core jscodeshift function "bound" to a specific
  * parser.
+ *
+ * @augments core
+ * @static
  */
 function withParser(parser) {
   if (typeof parser === 'string') {
@@ -139,11 +147,21 @@ function withParser(parser) {
   return enrichCore(newCore, parser);
 }
 
+/**
+* The ast-types library
+* @external astTypes
+* @see {@link https://github.com/benjamn/ast-types}
+*/
+
 function enrichCore(core, parser) {
   // add builders and types to the function for simple access
   Object.assign(core, recast.types.namedTypes);
   Object.assign(core, recast.types.builders);
   core.registerMethods = Collection.registerMethods;
+  /**
+  * @augments core
+  * @type external:astTypes
+  */
   core.types = recast.types;
   core.match = match;
   core.template = template(parser);


### PR DESCRIPTION
This is a first stab at getting auto-generated documentation for traversal/mutation methods setup. I currently have it building the docs to `/docs`, in hopes that it will work with the new GitHub pages setup (you don't need a separate branch for a project page anymore 🎉 ).

This will need more work, but I figured I'd submit progress so far and iterate.

Should also note that my `editorconfig` setup auto-removed some trailing spaces in places. Let me know if you want me to revert those changes.

I also attempted to use [DocumentionJS](https://github.com/documentationjs/documentation) and [ESDoc](https://esdoc.org/) for this, but they both didn't support enough of the JSDoc syntax that would be needed to generate docs for how this code is currently structured.

![image](https://cloud.githubusercontent.com/assets/5233399/18234930/69c92aba-72d8-11e6-82b7-5d96a3b51c01.png)

![image](https://cloud.githubusercontent.com/assets/5233399/18234936/82e66328-72d8-11e6-86df-0ea2f7f94aea.png)
