### PR TITLE
Deprecate Collection#size(), add Collection#length

### DIFF
--- a/src/Collection.js
+++ b/src/Collection.js
@@ -114,6 +114,15 @@ class Collection {
   }
 
   /**
+   * Returns the number of elements in this collection.
+   *
+   * @return {number}
+   */
+  get length() {
+    return this.__paths.length;
+  }
+
+  /**
    * Returns an array of AST nodes in this collection.
    *
    * @return {Array}
@@ -175,7 +184,7 @@ class Collection {
     if (!path) {
       throw Error(
         'You cannot call "get" on a collection with no paths. ' +
-        'Instead, check "size()" first to verify at least 1 path exists.'
+        'Instead, check the "length" property first to verify at least 1 path exists.'
       );
     }
     return path.get.apply(path, arguments);
@@ -309,23 +318,23 @@ function registerMethods(methods, type) {
     }
     if (hasConflictingRegistration(methodName, type)) {
       var msg = `There is a conflicting registration for method with name "${methodName}".\nYou tried to register an additional method with `;
-      
+
       if (type) {
         msg += `type "${type.toString()}".`
       } else {
         msg += 'universal type.'
       }
-      
+
       msg += '\nThere are existing registrations for that method with ';
-      
+
       var conflictingRegistrations = CPt[methodName].typedRegistrations;
-      
+
       if (conflictingRegistrations) {
-        msg += `type ${Object.keys(conflictingRegistrations).join(', ')}.`; 
+        msg += `type ${Object.keys(conflictingRegistrations).join(', ')}.`;
       } else {
         msg += 'universal type.';
       }
-      
+
       throw Error(msg);
     }
     if (!type) {
@@ -342,7 +351,7 @@ function registerMethods(methods, type) {
       });
     }
   }
-} 
+}
 
 function installTypedMethod(methodName) {
   if (CPt.hasOwnProperty(methodName)) {
@@ -353,14 +362,14 @@ function installTypedMethod(methodName) {
 
   function typedMethod() {
     var types = Object.keys(registrations);
-    
+
     for (var i = 0; i < types.length; i++) {
       var currentType = types[i];
       if (registrations[currentType] && this.isOfType(currentType)) {
         return registrations[currentType].apply(this, arguments);
       }
     }
-    
+
     throw Error(
       `You have a collection of type [${this.getTypes()}]. ` +
       `"${methodName}" is only defined for one of [${types.join('|')}].`
@@ -374,7 +383,7 @@ function installTypedMethod(methodName) {
 
 function hasConflictingRegistration(methodName, type) {
   if (!type) {
-    return CPt.hasOwnProperty(methodName); 
+    return CPt.hasOwnProperty(methodName);
   }
 
   if (!CPt.hasOwnProperty(methodName)) {
@@ -382,20 +391,20 @@ function hasConflictingRegistration(methodName, type) {
   }
 
   var registrations = CPt[methodName] && CPt[methodName].typedRegistrations;
-  
+
   if (!registrations) {
     return true;
   }
-  
+
   type = type.toString();
-  
+
   if (registrations.hasOwnProperty(type)) {
     return true;
   }
 
   return astTypes.getSupertypeNames(type.toString()).some(function (name) {
     return !!registrations[name];
-  }); 
+  });
 }
 
 var _defaultType = [];

--- a/src/__tests__/Collection-test.js
+++ b/src/__tests__/Collection-test.js
@@ -150,7 +150,7 @@ describe('Collection API', function() {
       var collection = Collection.fromNodes([
         b.functionExpression(null, [], b.blockStatement([])),
         b.functionExpression(null, [], b.blockStatement([])),
-        b.binaryExpression("+", b.identifier("a"), b.identifier("b"))
+        b.binaryExpression('+', b.identifier('a'), b.identifier('b'))
       ]);
 
       function typeFilter(type) {
@@ -205,7 +205,7 @@ describe('Collection API', function() {
         var fooVariables = Collection.fromNodes(nodes).filter(filter);
 
         expect(filter.mock.calls.length).toBe(2);
-        expect(fooVariables.size()).toBe(1);
+        expect(fooVariables.length).toBe(1);
       });
 
     });
@@ -234,7 +234,7 @@ describe('Collection API', function() {
         var mapped = root.map((_, i) => new NodePath(nodes[+!i]));
 
         expect(root).not.toBe(mapped);
-        expect(mapped.size()).toBe(2);
+        expect(mapped.length).toBe(2);
         expect(mapped.nodes()[0]).toBe(nodes[1]);
         expect(mapped.nodes()[1]).toBe(nodes[0]);
       });
@@ -245,7 +245,7 @@ describe('Collection API', function() {
         var mapped = root.map(_ => path);
 
         expect(root).not.toBe(mapped);
-        expect(mapped.size()).toBe(1);
+        expect(mapped.length).toBe(1);
         expect(mapped.paths()[0]).toBe(path);
       });
     });

--- a/src/collections/Node.js
+++ b/src/collections/Node.js
@@ -112,7 +112,7 @@ var traversalMethods = {
       if (!bindings) return;
       var decl = Collection.fromPaths(bindings)
         .closest(types.VariableDeclarator);
-      if (decl.size() === 1) {
+      if (decl.length === 1) {
         return decl.paths()[0];
       }
     }, types.VariableDeclarator);

--- a/src/collections/__tests__/JSXElement-test.js
+++ b/src/collections/__tests__/JSXElement-test.js
@@ -47,19 +47,19 @@ describe('JSXCollection API', function() {
     it('returns a non empty JSXCollection', function() {
       var jsx = Collection.fromNodes(nodes).find(types.JSXElement);
       expect(jsx.getTypes()).toContain('JSXElement');
-      expect(jsx.size()).toBeGreaterThan(0);
+      expect(jsx.length).toBeGreaterThan(0);
     });
 
     it('lets us find JSXElements by name conveniently', function() {
       var jsx = Collection.fromNodes(nodes).findJSXElements('Child');
 
-      expect(jsx.size()).toBe(3);
+      expect(jsx.length).toBe(3);
     });
 
     it('finds JSXElements by module name', function() {
       var jsx = Collection.fromNodes(nodes).findJSXElementsByModuleName('XYZ');
 
-      expect(jsx.size()).toBe(1);
+      expect(jsx.length).toBe(1);
     });
 
     it('returns the child nodes of an JSXElement', function() {
@@ -67,7 +67,7 @@ describe('JSXCollection API', function() {
         Collection.fromNodes(nodes)
         .findJSXElements('FooBar')
         .childNodes();
-      expect(children.size()).toBe(5);
+      expect(children.length).toBe(5);
       expect(children.getTypes()).toContain('Expression');
     });
 
@@ -77,7 +77,7 @@ describe('JSXCollection API', function() {
         .findJSXElements('FooBar')
         .childElements();
 
-      expect(children.size()).toBe(2);
+      expect(children.length).toBe(2);
       expect(children.getTypes()).toContain('JSXElement');
     });
 
@@ -87,7 +87,7 @@ describe('JSXCollection API', function() {
         .findJSXElements('Foo')
         .childElements();
 
-      expect(children.size()).toBe(0);
+      expect(children.length).toBe(0);
       expect(children.getTypes()).toContain('JSXElement');
     });
   });
@@ -96,8 +96,8 @@ describe('JSXCollection API', function() {
     it('filters elements by attributes', function() {
       var jsx = Collection.fromNodes(nodes)
         .findJSXElements()
-        .filter(JSXElementCollection.filters.hasAttributes({foo: "bar"}));
-      expect(jsx.size()).toBe(2);
+        .filter(JSXElementCollection.filters.hasAttributes({foo: 'bar'}));
+      expect(jsx.length).toBe(2);
     });
 
     it('accepts callback functions as attribute filters', function() {
@@ -106,14 +106,14 @@ describe('JSXCollection API', function() {
         .filter(JSXElementCollection.filters.hasAttributes(
             {foo: v => ['bar', 'baz'].indexOf(v) > -1}
         ));
-      expect(jsx.size()).toBe(3);
+      expect(jsx.length).toBe(3);
     });
 
     it('filters elements by children', function() {
       var jsx = Collection.fromNodes(nodes)
         .findJSXElements()
         .filter(JSXElementCollection.filters.hasChildren('Child'));
-      expect(jsx.size()).toBe(2);
+      expect(jsx.length).toBe(2);
     });
   });
 

--- a/src/collections/__tests__/Node-test.js
+++ b/src/collections/__tests__/Node-test.js
@@ -62,7 +62,7 @@ describe('Collection API', function() {
         ]);
         var vars = Collection.fromNodes([ast]).find(types.Identifier);
 
-        expect(vars.size()).toBe(2);
+        expect(vars.length).toBe(2);
       });
 
       it('doesn\'t find the nodes in the collection itself', function() {
@@ -73,7 +73,7 @@ describe('Collection API', function() {
         ];
         var vars = Collection.fromNodes(nodes).find(types.Identifier);
 
-        expect(vars.size()).toBe(0);
+        expect(vars.length).toBe(0);
       });
 
       it('finds nodes by type and properties', function() {
@@ -85,7 +85,7 @@ describe('Collection API', function() {
         var vars = Collection.fromNodes([ast])
           .find(types.Identifier, {name: 'bar'});
 
-        expect(vars.size()).toBe(1);
+        expect(vars.length).toBe(1);
         expect(vars.nodes()[0]).toBe(ast.expressions[2]);
       });
 
@@ -94,7 +94,7 @@ describe('Collection API', function() {
           .find(types.FunctionDeclaration)
           .find(types.VariableDeclarator, {id: {name: 'bar'}});
 
-        expect(vars.size()).toBe(1);
+        expect(vars.length).toBe(1);
         expect(vars.nodes()[0]).toBe(
           ast.body[1].body.body[0].declarations[0]
         );
@@ -110,9 +110,9 @@ describe('Collection API', function() {
         var baz = functionDeclarations
           .find(types.VariableDeclarator, {id: {name: 'baz'}});
 
-        expect(bar.size()).toBe(1);
+        expect(bar.length).toBe(1);
         expect(bar.nodes()[0]).toBe(functionBody[0].declarations[0]);
-        expect(baz.size()).toBe(1);
+        expect(baz.length).toBe(1);
         expect(baz.nodes()[0]).toBe(functionBody[1].declarations[0]);
       });
     });
@@ -155,7 +155,7 @@ describe('Collection API', function() {
           .find(types.Identifier)
           .closest(types.FunctionDeclaration);
 
-        expect(decl.size()).toBe(1);
+        expect(decl.length).toBe(1);
         expect(decl.nodes()[0]).toBe(functionDeclaration);
       });
 
@@ -206,7 +206,7 @@ describe('Collection API', function() {
         var decl = Collection.fromNodes([program])
           .find(types.Identifier)
           .getVariableDeclarators(p => p.value.name);
-        expect(decl.size()).toBe(1);
+        expect(decl.length).toBe(1);
         expect(decl.nodes()[0]).toBe(variableDeclarator);
       });
     });

--- a/src/collections/__tests__/VariableDeclarator-test.js
+++ b/src/collections/__tests__/VariableDeclarator-test.js
@@ -65,13 +65,13 @@ describe('VariableDeclarators', function() {
     it('finds all variable declarators', function() {
       var declarators = Collection.fromNodes(nodes).findVariableDeclarators();
       expect(declarators.getTypes()).toContain('VariableDeclarator');
-      expect(declarators.size()).toBe(7);
+      expect(declarators.length).toBe(7);
     });
 
     it('finds variable declarators by name', function() {
       var declarators = Collection.fromNodes(nodes)
         .findVariableDeclarators('bar');
-      expect(declarators.size()).toBe(2);
+      expect(declarators.length).toBe(2);
     });
   });
 
@@ -81,7 +81,7 @@ describe('VariableDeclarators', function() {
         .findVariableDeclarators()
         .filter(VariableDeclaratorCollection.filters.requiresModule());
 
-      expect(declarators.size()).toBe(2);
+      expect(declarators.length).toBe(2);
     });
 
     it('finds module imports (require) by module name', function() {
@@ -89,7 +89,7 @@ describe('VariableDeclarators', function() {
         .findVariableDeclarators()
         .filter(VariableDeclaratorCollection.filters.requiresModule('module'));
 
-      expect(declarators.size()).toBe(1);
+      expect(declarators.length).toBe(1);
     });
 
     it('accepts multiple module names', function() {
@@ -99,7 +99,7 @@ describe('VariableDeclarators', function() {
           ['module', 'module2']
         ));
 
-      expect(declarators.size()).toBe(2);
+      expect(declarators.length).toBe(2);
     });
   });
 
@@ -114,7 +114,7 @@ describe('VariableDeclarators', function() {
         Collection.fromNodes(nodes)
         .find(types.Identifier, {name: 'xyz'});
 
-      expect(identifiers.size()).toBe(6);
+      expect(identifiers.length).toBe(6);
     });
 
     it('does not rename things that are not variables', function() {
@@ -126,7 +126,7 @@ describe('VariableDeclarators', function() {
         Collection.fromNodes(nodes)
         .find(types.Identifier, {name: 'blarg'});
 
-      expect(identifiers.size()).toBe(1);
+      expect(identifiers.length).toBe(1);
     });
   });
 


### PR DESCRIPTION
Implements #150 (assuming it is wanted).

I was going to use [`util.deprecate`](https://nodejs.org/api/util.html#util_util_deprecate_function_string), but cannot do that without using the class fields proposal, so I'm just writing a warning to `stderr` atm.

`EditorConfig` setup in Atom killed some extra whitespace. Happy to revert if requested.