### PR TITLE
Fix replaceWith to retain correlated comments

### DIFF
--- a/src/collections/Node.js
+++ b/src/collections/Node.js
@@ -136,7 +136,11 @@ var mutationMethods = {
     return this.forEach(function(path, i) {
       var newNodes =
         (typeof nodes === 'function') ? nodes.call(path, path, i) : nodes;
+      var comments = path.value.comments;
+      var loc = path.value.loc;
       path.replace.apply(path, toArray(newNodes));
+      path.value.comments = comments;
+      path.value.loc = loc;
     });
   },
 

--- a/src/collections/__tests__/Node-test.js
+++ b/src/collections/__tests__/Node-test.js
@@ -12,6 +12,8 @@
 
 jest.autoMockOff();
 
+var babel = require('babel-core');
+
 describe('Collection API', function() {
   var ast;
   var Collection;
@@ -273,6 +275,23 @@ describe('Collection API', function() {
         expect(S.nodes()[0].expressions[0]).toEqual(b.identifier('foo0'));
         // baz1 is properly replaced
         expect(S.nodes()[0].expressions[2]).toEqual(b.identifier('bar1'));
+      });
+
+      it('retains comment blocks through replacements', function() {
+        var nodes = [recast.parse([
+          '// Test comment',
+          'import a from \'abc\';',
+        ].join('\n'), {parser: babel}).program];
+        var S = Collection.fromNodes(nodes);
+        var newImport = b.importDeclaration(
+          [b.importDefaultSpecifier(b.identifier('test'))],
+          b.literal('test-module1')
+        );
+        S.find(types.ImportDeclaration)
+         .replaceWith(newImport);
+        var importNode = S.find(types.ImportDeclaration).nodes()[0];
+        expect(importNode.comments).not.toEqual(null);
+        expect(importNode.comments[0].value).toEqual(' Test comment');
       });
     });
 


### PR DESCRIPTION
This fixes the bug that requires this recipe: [retain-first-comment](https://github.com/facebook/jscodeshift/blob/master/recipes/retain-first-comment.md). Essentially if the initial expression is replaced, the top-of-file comments are removed by default. An eslint autofixer had this issue, and a [codemod](https://github.com/zackargyle/codemods/blob/master/underscore-to-native.js) I recently wrote had the same issue until I fixed it, but it seems like this should be default behavior. I've verified that it works on my codemod.


