### PR TITLE
Add j shorthand

### DIFF
--- a/src/Worker.js
+++ b/src/Worker.js
@@ -124,13 +124,15 @@ function run(data) {
         }
         source = source.toString();
         try {
+          var jscodeshift = prepareJscodeshift(options);
           var out = transform(
             {
               path: file,
               source: source,
             },
             {
-              jscodeshift: prepareJscodeshift(options),
+              j: jscodeshift,
+              jscodeshift: jscodeshift,
               stats: options.dry ? stats : empty
             },
             options

--- a/src/__tests__/Worker-test.js
+++ b/src/__tests__/Worker-test.js
@@ -40,6 +40,25 @@ describe('Worker API', () => {
     });
   });
 
+  it('passes j as argument', done => {
+    var transformPath = createTempFileWith(
+      `module.exports = function (file, api) {
+        return api.j(file.source).toSource() + ' changed';
+       }`
+    );
+    var sourcePath = createTempFileWith('const x = 10;');
+
+    const emitter = worker([transformPath]);
+    emitter.send({files: [sourcePath]});
+    emitter.once('message', (data) => {
+      expect(data.status).toBe('ok');
+      expect(getFileContent(sourcePath)).toBe(
+        'const x = 10;' + ' changed'
+      );
+      done();
+    });
+  });
+
   describe('custom parser', () => {
     function getTransformForParser(parser) {
       return createTempFileWith(


### PR DESCRIPTION
This way we can write

```js
export default function transformer(file, { j }) {
  return j(file.source).toSource();
}
```

and not need to have the annoying local variable

```js
export default function transformer(file, api) {
  const j = api.jscodeshift;

  return j(file.source).toSource();
}
```