### PR TITLE
Atomically write transformed JS files back to the filesystem

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "node-dir": "0.1.8",
     "nomnom": "^1.8.1",
     "recast": "^0.11.11",
-    "temp": "^0.8.1"
+    "temp": "^0.8.1",
+    "write-file-atomic": "^1.2.0"
   },
   "devDependencies": {
     "babel-eslint": "^6.1.2",

--- a/src/Worker.js
+++ b/src/Worker.js
@@ -146,13 +146,21 @@ function run(data) {
             console.log(out); // eslint-disable-line no-console
           }
           if (!options.dry) {
-            fs.writeFile(file, out, function(err) {
+            const tmpFile = `${file}.tmp.${Math.floor(Math.random() * 1000000)}`;
+            fs.writeFile(tmpFile, out, function(err) {
               if (err) {
                 updateStatus('error', file, 'File writer error: ' + err);
+                callback();
               } else {
-                updateStatus('ok', file);
+                fs.rename(tmpFile, file, function(err) {
+                  if (err) {
+                    updateStatus('error', file, 'File move error: ' + err);
+                  } else {
+                    updateStatus('ok', file);
+                  }
+                  callback();
+                });
               }
-              callback();
             });
           } else {
             updateStatus('ok', file);

--- a/src/Worker.js
+++ b/src/Worker.js
@@ -14,6 +14,7 @@ const EventEmitter = require('events').EventEmitter;
 
 const async = require('async');
 const fs = require('fs');
+const writeFileAtomic = require('write-file-atomic');
 const getParser = require('./getParser');
 
 const jscodeshift = require('./core');
@@ -146,21 +147,13 @@ function run(data) {
             console.log(out); // eslint-disable-line no-console
           }
           if (!options.dry) {
-            const tmpFile = `${file}.tmp.${Math.floor(Math.random() * 1000000)}`;
-            fs.writeFile(tmpFile, out, function(err) {
+            writeFileAtomic(file, out, function(err) {
               if (err) {
                 updateStatus('error', file, 'File writer error: ' + err);
-                callback();
               } else {
-                fs.rename(tmpFile, file, function(err) {
-                  if (err) {
-                    updateStatus('error', file, 'File move error: ' + err);
-                  } else {
-                    updateStatus('ok', file);
-                  }
-                  callback();
-                });
+                updateStatus('ok', file);
               }
+              callback();
             });
           } else {
             updateStatus('ok', file);


### PR DESCRIPTION
Instead of directly overwriting each JS file with its new contents, the worker
code now writes the new contents to a temporary file and then does a filesystem
move operation to overwrite the old file. This avoids the previous behavior
where the file had invalid contents while it was being written (because
`writeFile` is not atomic).

This fixes a race condition I was seeing in a script I was running on a large codebase:
https://github.com/alangpierce/bulk-decaffeinate/blob/master/jscodeshift-scripts/fix-imports.js

The script fixes import statements across the codebase by reading the exports
of the referenced files (using `readFileSync` and using jscodeshift to parse
the other file). Because the other files were also being transformed by
jscodeshift, sometimes (nondeterminsitically) some imports would fail to
convert because the referenced file wouldn't be valid. After applying this fix
and re-running the script on my codebase, it seems to completely fix the
problem.