### PR TITLE
Multiple transform support for Workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Usage: jscodeshift <path>... [options]
 path     Files or directory to transform
 
 Options:
-   -t FILE, --transform FILE   Path to a transform file. Can be either a local path or url. Can be given multiple times to run several transforms in order  [./transform.js]
+   -t NAME, --transform NAME   Path to a transform url, file, directory, or npm package. Can be given multiple times to run several transforms in order  [.]
    -c, --cpus                  (all by default) Determines the number of processes started.
    -v, --verbose               Show more information about the transform process  [0]
    -d, --dry                   Dry run (no changes are made to files)
@@ -47,8 +47,8 @@ Options:
 ```
 
 This passes the source of all passed through the transform modules specified
-with `-t` or `--transform` (they default to a `transform.js` file in the current
-directory). The next section explains the structure of transform modules.
+with `-t` or `--transform` (they default to the current directory). The next
+section explains the structure of transform modules.
 
 ## Transform module
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Usage: jscodeshift <path>... [options]
 path     Files or directory to transform
 
 Options:
-   -t FILE, --transform FILE   Path to the transform file. Can be either a local path or url  [./transform.js]
+   -t FILE, --transform FILE   Path to a transform file. Can be either a local path or url. Can be given multiple times to run several transforms in order  [./transform.js]
    -c, --cpus                  (all by default) Determines the number of processes started.
    -v, --verbose               Show more information about the transform process  [0]
    -d, --dry                   Dry run (no changes are made to files)
@@ -46,13 +46,13 @@ Options:
    --version                   print version and exit
 ```
 
-This passes the source of all passed through the transform module specified
-with `-t` or `--transform` (defaults to `transform.js` in the current
-directory). The next section explains the structure of the transform module.
+This passes the source of all passed through the transform modules specified
+with `-t` or `--transform` (they default to a `transform.js` file in the current
+directory). The next section explains the structure of transform modules.
 
 ## Transform module
 
-The transform is simply a module that exports a function of the form:
+A transform is simply a module that exports a function of the form:
 
 ```js
 module.exports = function(fileInfo, api, options) {

--- a/README.md
+++ b/README.md
@@ -48,7 +48,20 @@ Options:
 
 This passes the source of all passed through the transform modules specified
 with `-t` or `--transform` (they default to the current directory). The next
-section explains the structure of transform modules.
+section explains how transform modules are located, and the section after that
+explains the structure of transform modules.
+
+## Transform location algorithm
+The default transform is the current directory if no `--transform` flag is given.
+
+1. If URL, return file at URL
+2. If file, return file
+3. If directory
+  1. If contains directory named `transforms`, return files in that directory
+  2. If contains file named `transform.js`, return file
+  3. Else, return files in directory
+4. If npm package, find its directory (with `require.resolve()`) and go to step 3
+5. Else, error
 
 ## Transform module
 

--- a/bin/__tests__/jscodeshift-test.js
+++ b/bin/__tests__/jscodeshift-test.js
@@ -77,6 +77,25 @@ describe('jscodeshift CLI', () => {
     ]);
   });
 
+  it('calls multiple transforms in order', () => {
+    var sourceA = createTempFileWith('a');
+    var sourceB = createTempFileWith('b');
+    var transformA = createTransformWith(
+      'return "first" + fileInfo.source;'
+    );
+    var transformB = createTransformWith(
+      'return "second" + fileInfo.source;'
+    );
+
+    return run(['-t', transformA, '-t', transformB, sourceA, sourceB]).then(
+      out => {
+        expect(out[1]).toBe('');
+        expect(fs.readFileSync(sourceA).toString()).toBe('secondfirsta');
+        expect(fs.readFileSync(sourceB).toString()).toBe('secondfirstb');
+      }
+    );
+  });
+
   it('does not transform files in a dry run', () => {
     var source = createTempFileWith('a');
     var transform = createTransformWith(

--- a/bin/__tests__/jscodeshift-test.js
+++ b/bin/__tests__/jscodeshift-test.js
@@ -19,7 +19,7 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 600000; // 10 minutes
 var child_process = require('child_process');
 var fs = require('fs');
 var path = require('path');
-var temp = require('temp');
+var temp = require('temp').track();
 var mkdirp = require('mkdirp');
 var testUtils = require('../../utils/testUtils');
 

--- a/bin/jscodeshift.sh
+++ b/bin/jscodeshift.sh
@@ -108,10 +108,13 @@ const opts = require('nomnom')
   })
   .parse();
 
-opts.transform.forEach(transform => {
-  Runner.run(
-    /^https?/.test(transform) ? transform : path.resolve(transform),
-    opts.path,
-    opts
-  );
-});
+// Force transforms to run in order with Promise chaining
+opts.transform.reduce((promise, transform) => {
+  return promise.then(() => {
+    return Runner.run(
+      /^https?/.test(transform) ? transform : path.resolve(transform),
+      opts.path,
+      opts
+    );
+  });
+}, Promise.resolve());

--- a/bin/jscodeshift.sh
+++ b/bin/jscodeshift.sh
@@ -28,7 +28,7 @@ const opts = require('nomnom')
     transform: {
       abbr: 't',
       default: ['./transform.js'],
-      help: 'Path to the transform file. Can be either a local path or url',
+      help: 'Path to a transform file. Can be either a local path or url. Can be given multiple times to run several transforms in order',
       list: true,
       metavar: 'FILE'
     },

--- a/bin/jscodeshift.sh
+++ b/bin/jscodeshift.sh
@@ -108,13 +108,8 @@ const opts = require('nomnom')
   })
   .parse();
 
-// Force transforms to run in order with Promise chaining
-opts.transform.reduce((promise, transform) => {
-  return promise.then(() => {
-    return Runner.run(
-      /^https?/.test(transform) ? transform : path.resolve(transform),
-      opts.path,
-      opts
-    );
-  });
-}, Promise.resolve());
+const transforms = opts.transform.map(transform => {
+  return /^https?/.test(transform) ? transform : path.resolve(transform);
+});
+
+Runner.run(transforms, opts.path, opts);

--- a/bin/jscodeshift.sh
+++ b/bin/jscodeshift.sh
@@ -27,10 +27,10 @@ const opts = require('nomnom')
     },
     transform: {
       abbr: 't',
-      default: ['./transform.js'],
-      help: 'Path to a transform file. Can be either a local path or url. Can be given multiple times to run several transforms in order',
+      default: ['.'],
+      help: 'Path to a transform url, file, directory, or npm package. Can be given multiple times to run several transforms in order',
       list: true,
-      metavar: 'FILE'
+      metavar: 'NAME'
     },
     cpus: {
       abbr: 'c',

--- a/bin/jscodeshift.sh
+++ b/bin/jscodeshift.sh
@@ -27,8 +27,9 @@ const opts = require('nomnom')
     },
     transform: {
       abbr: 't',
-      default: './transform.js',
+      default: ['./transform.js'],
       help: 'Path to the transform file. Can be either a local path or url',
+      list: true,
       metavar: 'FILE'
     },
     cpus: {
@@ -107,8 +108,10 @@ const opts = require('nomnom')
   })
   .parse();
 
-Runner.run(
-  /^https?/.test(opts.transform) ? opts.transform : path.resolve(opts.transform), 
-  opts.path,
-  opts
-);
+opts.transform.forEach(transform => {
+  Runner.run(
+    /^https?/.test(transform) ? transform : path.resolve(transform),
+    opts.path,
+    opts
+  );
+});

--- a/src/Runner.js
+++ b/src/Runner.js
@@ -18,7 +18,7 @@ const fs = require('fs');
 const path = require('path');
 const http = require('http');
 const https = require('https');
-const temp = require('temp');
+const temp = require('temp').track();
 const ignores = require('./ignoreFiles');
 
 const availableCpus = Math.max(require('os').cpus().length - 1, 1);

--- a/src/Runner.js
+++ b/src/Runner.js
@@ -318,4 +318,5 @@ function run(transforms, paths, options) {
   }
 }
 
+exports.getTransform = getTransform;
 exports.run = run;

--- a/src/Runner.js
+++ b/src/Runner.js
@@ -135,11 +135,11 @@ function getAllFiles(paths, filter) {
   ).then(concatAll);
 }
 
-function getTransform(transformFile) {
-  if (/^http/.test(transformFile)) {
+function getTransform(transform) {
+  if (/^http/.test(transform)) {
     return new Promise((resolve, reject) => {
       // call the correct `http` or `https` implementation
-      (transformFile.indexOf('https') !== 0 ?  http : https).get(transformFile, (res) => {
+      (transform.indexOf('https') !== 0 ?  http : https).get(transform, (res) => {
         let contents = '';
         res
           .on('data', (d) => {
@@ -160,14 +160,14 @@ function getTransform(transformFile) {
         reject(e.message);
       });
     });
-  } else if (!fs.existsSync(transformFile)) {
-    return Promise.reject('Transform file ' + transformFile + ' does not exist');
+  } else if (!fs.existsSync(transform)) {
+    return Promise.reject('Transform file ' + transform + ' does not exist');
   } else {
-    return transformFile;
+    return transform;
   }
 }
 
-function run(transformFiles, paths, options) {
+function run(transforms, paths, options) {
   const cpus = options.cpus ? Math.min(availableCpus, options.cpus) : availableCpus;
   const extensions =
     options.extensions && options.extensions.split(',').map(ext => '.' + ext);
@@ -178,9 +178,9 @@ function run(transformFiles, paths, options) {
   ignores.add(options.ignorePattern);
   ignores.addFromFile(options.ignoreConfig);
 
-  transformFiles = Array.isArray(transformFiles) ? transformFiles : [transformfiles]
+  transforms = Array.isArray(transforms) ? transforms : [transformfiles]
 
-  return Promise.all(transformFiles.map(getTransform)).catch(reason => {
+  return Promise.all(transforms.map(getTransform)).catch(reason => {
     // If there's an error, log it but continue to reject
     process.stderr.write(colors.white.bgRed('ERROR') + ' ' + reason + '\n');
     return Promise.reject(reason);

--- a/src/Runner.js
+++ b/src/Runner.js
@@ -164,10 +164,10 @@ function getTransform(transform) {
   } else if (fs.existsSync(transform)) {
     let stats = fs.lstat(transform);
 
-    if (stats.isFile(transform)) {
+    if (stats && stats.isFile(transform)) {
       // handle file
       return transform;
-    } else if (stats.isDirectory(transform)) {
+    } else if (stats && stats.isDirectory(transform)) {
       let directory = path.join(transform, 'transforms');
       let file = path.join(transform, 'transformjs');
 
@@ -179,15 +179,16 @@ function getTransform(transform) {
       } else {
         return fs.readdirSync(transform);
       }
+    } else {
+      // handle other fs objects
+      return transform;
     }
-
-    // if it's something other than a file or directory, keep going
   }
 
   try {
     // handle npm package as directory
     return getTransform(require.resolve(transform));
-  } catch () {
+  } catch (e) {
     // error
     return Promise.reject('Transform ' + transform + ' does not exist');
   }

--- a/src/Runner.js
+++ b/src/Runner.js
@@ -162,7 +162,7 @@ function getTransform(transform) {
       });
     });
   } else if (fs.existsSync(transform)) {
-    let stats = fs.lstat(transform);
+    let stats = fs.lstatSync(transform);
 
     if (stats && stats.isFile(transform)) {
       // handle file
@@ -172,9 +172,9 @@ function getTransform(transform) {
       let file = path.join(transform, 'transformjs');
 
       // handle directory
-      if (fs.existsSync(directory) && fs.lstat(directory).isDirectory()) {
+      if (fs.existsSync(directory) && fs.lstatSync(directory).isDirectory()) {
         return fs.readdirSync(directory);
-      } else if (fs.existsSync(file) && fs.lstat(file).isFile()) {
+      } else if (fs.existsSync(file) && fs.lstatSync(file).isFile()) {
         return file;
       } else {
         return fs.readdirSync(transform);
@@ -214,7 +214,7 @@ function run(transforms, paths, options) {
       process.stderr.write(colors.white.bgRed('ERROR') + ' ' + reason + '\n');
       return Promise.reject(reason);
     })
-    .then(Array.prototype.concat) // flatten nested Arrays
+    .then(Array.prototype.concat.bind([])) // flatten nested Arrays
     .then(transform);
 
   function transform(transformFiles) {

--- a/src/__tests__/Runner-test.js
+++ b/src/__tests__/Runner-test.js
@@ -12,16 +12,22 @@ const getTransform = require('../Runner').getTransform;
 
 describe('Runner API', () => {
   describe('getTransform', () => {
-    it('finds a URL');
+    it('finds a file given a URL');
     it('finds a file');
-    it('finds a directory\'s transforms subdirectory');
-    it('finds a directory\'s transform.js file');
-    it('finds a directory\'s transforms');
-    it('finds a package\'s transforms subdirectory');
-    it('finds a package\'s transform.js file');
-    it('finds a package\'s transforms');
 
-    it('errors on failure', () => {
+    describe('given a directory', () => {
+      it('finds a transforms subdirectory');
+      it('finds a transform.js file');
+      it('finds transforms');
+    });
+
+    describe('given a package', () => {
+      it('finds a transforms subdirectory');
+      it('finds a transform.js file');
+      it('finds transforms');
+    });
+
+    it('rejects a Promise given an invalid identifier', () => {
       function expectError(error) {
         expect(error).toBe('Transform not valid does not exist');
       }

--- a/src/__tests__/Runner-test.js
+++ b/src/__tests__/Runner-test.js
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2016-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+const getTransform = require('../Runner').getTransform;
+
+describe('Runner API', () => {
+  describe('getTransform', () => {
+    it('errors on failure', () => {
+      function expectError(error) {
+        expect(error).toBe('Transform not valid does not exist');
+      }
+
+      // Expect a specific Promise rejection.
+      return Promise
+        .resolve(getTransform('not valid'))
+        .then(expectError, expectError);
+    });
+  });
+});

--- a/src/__tests__/Runner-test.js
+++ b/src/__tests__/Runner-test.js
@@ -12,6 +12,15 @@ const getTransform = require('../Runner').getTransform;
 
 describe('Runner API', () => {
   describe('getTransform', () => {
+    it('finds a URL');
+    it('finds a file');
+    it('finds a directory\'s transforms subdirectory');
+    it('finds a directory\'s transform.js file');
+    it('finds a directory\'s transforms');
+    it('finds a package\'s transforms subdirectory');
+    it('finds a package\'s transform.js file');
+    it('finds a package\'s transforms');
+
     it('errors on failure', () => {
       function expectError(error) {
         expect(error).toBe('Transform not valid does not exist');

--- a/src/__tests__/Runner-test.js
+++ b/src/__tests__/Runner-test.js
@@ -9,9 +9,13 @@
  */
 
 const getTransform = require('../Runner').getTransform;
+const temp = require('temp').track();
 
 describe('Runner API', () => {
   describe('getTransform', () => {
+    beforeAll(temp.cleanupSync);
+    afterEach(temp.cleanupSync);
+
     it('finds a file given a URL');
     it('finds a file');
 

--- a/src/__tests__/Worker-test.js
+++ b/src/__tests__/Worker-test.js
@@ -39,6 +39,23 @@ describe('Worker API', () => {
     });
   });
 
+  it('transforms files with multiple transforms', done => {
+    const transformPath1 =
+      createTransformWith('return fileInfo.source + " changed";');
+    const transformPath2 =
+      createTransformWith('return fileInfo.source + " again";');
+    const sourcePath = createTempFileWith('foo');
+    const emitter = worker([[transformPath1, transformPath2]]);
+
+    emitter.send({files: [sourcePath]});
+    emitter.once('message', (data) => {
+      expect(data.status).toBe('ok');
+      expect(data.msg).toBe(sourcePath);
+      expect(getFileContent(sourcePath)).toBe('foo changed again');
+      done();
+    });
+  });
+
   it('passes j as argument', done => {
     const transformPath = createTempFileWith(
       `module.exports = function (file, api) {

--- a/utils/testUtils.js
+++ b/utils/testUtils.js
@@ -13,7 +13,7 @@
 const fs = require('fs');
 const mkdirp = require('mkdirp');
 const path = require('path');
-const temp = require('temp');
+const temp = require('temp').track();
 
 function renameFileTo(oldPath, newFilename) {
   const projectPath = path.dirname(oldPath);


### PR DESCRIPTION
Fixes #126 and #148.
- [x] Allow the `--transform` flag to be repeated to run multiple transforms in order.
- [x] Change the Runner's API to support multiple transforms. ~~I wanted to do this at first, but I wasn't sure if it would make sense to add a potentially breaking change to this PR.~~
- [x] Support passing a directory or npm package instead of specific files.
- [ ] Keep the AST in memory between each transform, instead of writing and reading to disk between transforms.
- [ ] Test all new use cases.