### PR TITLE
Update first-comment recipe for when the first node is not updated

### DIFF
--- a/recipes/retain-first-comment.md
+++ b/recipes/retain-first-comment.md
@@ -47,16 +47,26 @@ foo();
 export default function transformer(file, api) {
   const j = api.jscodeshift;
   const root = j(file.source);
-  
-  const { comments } = root.find(j.Program).get('body', 0).node;
+
+  const getFirstNode = () => root.find(j.Program).get('body', 0).node;
+
+  // Save the comments attached to the first node
+  const firstNode = getFirstNode();
+  const { comments } = firstNode;
+
   root.find(j.VariableDeclaration).replaceWith(
     j.expressionStatement(j.callExpression(
         j.identifier('foo'),
         []
     ))
   );
-  root.get().node.comments = comments;
-  
+
+  // If the first node has been modified or deleted, reattach the comments
+  const firstNode2 = getFirstNode();
+  if (firstNode2 !== firstNode) {
+    firstNode2.comments = comments;
+  }
+
   return root.toSource();
 };
 ```


### PR DESCRIPTION
The comments on the first line would be duplicated if the first node was not modified.

https://github.com/5to6/5to6-codemod/issues/18
https://github.com/facebook/jscodeshift/issues/44#issuecomment-271335348