### PR TITLE
Methods to find JSX elements from ES6 imports

### DIFF
--- a/src/collections/JSXElement.js
+++ b/src/collections/JSXElement.js
@@ -65,7 +65,64 @@ const globalMethods = {
             .paths();
         }
       });
-  }
+  },
+
+  /**
+   * Finds all JSXElements by package name. Given
+   *
+   *     import Bar from 'Foo';
+   *     <Bar />
+   *
+   * findJSXElementsByImport('Foo') will find <Bar />, without having to
+   * know the variable name.
+   */
+  findJSXElementsByImport: function(importName) {
+    assert.ok(
+      importName && typeof importName === 'string',
+      'findJSXElementsByImport(...) needs a name to look for'
+    );
+
+    return this.find(types.ImportDeclaration, { source: { value: importName } })
+      .find(types.ImportDefaultSpecifier)
+      .map(path => {
+        const id = path.node.local.name;
+        if (id) {
+          return Collection.fromPaths([path])
+            .closestScope()
+            .findJSXElements(id)
+            .paths();
+        }
+      });
+  },
+
+  /**
+   * Finds all JSXElements by named import. Given
+   *
+   *     import { Foo as Bar } from 'foo';
+   *     <Bar />
+   *
+   * findJSXElementsByModuleName('foo', 'Foo') will find <Bar />, without having
+   * to know the variable name.
+   */
+  findJSXElementsByNamedImport: function(importName, exportName) {
+    assert.ok(
+      importName && typeof importName === 'string' &&
+      exportName && typeof exportName === 'string',
+      'findJSXElementsByNamedImport(...) needs a name to look for'
+    );
+
+    return this.find(types.ImportDeclaration, { source: { value: importName } })
+      .find(types.ImportSpecifier, { imported: { name: exportName }})
+      .map(path => {
+        const id = path.node.local.name;
+        if (id) {
+          return Collection.fromPaths([path])
+            .closestScope()
+            .findJSXElements(id)
+            .paths();
+        }
+      });
+  },
 };
 
 const filterMethods = {

--- a/src/collections/__tests__/JSXElement-test.js
+++ b/src/collections/__tests__/JSXElement-test.js
@@ -33,12 +33,14 @@ describe('JSXCollection API', function() {
 
     nodes = [recast.parse([
       'var FooBar = require("XYZ");',
+      'import Default from "default";',
+      'import { InternalName as Named } from "named";',
       '<FooBar foo="bar" bar="foo">',
-      '  <Child id="1" foo="bar">',
+      '  <Default id="1" foo="bar">',
       '     <Child />',
       '     <Baz.Bar />',
-      '  </Child>',
-      '  <Child id="2" foo="baz"/>',
+      '  </Default>',
+      '  <Named id="2" foo="baz"/>',
       '</FooBar>'
     ].join('\n'), {parser: babel}).program];
   });
@@ -51,13 +53,29 @@ describe('JSXCollection API', function() {
     });
 
     it('lets us find JSXElements by name conveniently', function() {
-      const jsx = Collection.fromNodes(nodes).findJSXElements('Child');
+      const jsx = Collection.fromNodes(nodes).findJSXElements('Default');
 
-      expect(jsx.length).toBe(3);
+      expect(jsx.length).toBe(1);
     });
 
     it('finds JSXElements by module name', function() {
       const jsx = Collection.fromNodes(nodes).findJSXElementsByModuleName('XYZ');
+
+      expect(jsx.length).toBe(1);
+    });
+
+    it('finds JSXElements by package name', function() {
+      const jsx = Collection
+        .fromNodes(nodes)
+        .findJSXElementsByImport('default');
+
+      expect(jsx.length).toBe(1);
+    });
+
+    it('finds JSXElements by named export and package name', function() {
+      const jsx = Collection
+        .fromNodes(nodes)
+        .findJSXElementsByNamedImport('named', 'InternalName');
 
       expect(jsx.length).toBe(1);
     });
@@ -112,8 +130,8 @@ describe('JSXCollection API', function() {
     it('filters elements by children', function() {
       const jsx = Collection.fromNodes(nodes)
         .findJSXElements()
-        .filter(JSXElementCollection.filters.hasChildren('Child'));
-      expect(jsx.length).toBe(2);
+        .filter(JSXElementCollection.filters.hasChildren('Default'));
+      expect(jsx.length).toBe(1);
     });
   });
 


### PR DESCRIPTION
This PR adds two extra methods to Collection that helps people find JSXElements when using ES6 imports. An example:

```jsx
import Foo from 'foo';
import { Bar as NewBar } from 'bar';

<Foo />
<NewBar />
```

```jsx
nodes.findJSXElementsByImport('foo'); // returns <Foo />
nodes.findJSXElementsByNamedImport('bar', 'Bar'); // returns <NewBar />
```

Tests included.