### PR TITLE
Drop `es6-promise`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "babel-register": "^6.9.0",
     "babylon": "^6.8.1",
     "colors": "^1.1.2",
-    "es6-promise": "^3.0.0",
     "flow-parser": "^0.*",
     "lodash": "^4.13.1",
     "micromatch": "^2.3.7",
@@ -47,8 +46,8 @@
   "devDependencies": {
     "babel-eslint": "^6.1.2",
     "eslint": "^3.1.1",
-    "jsdoc": "^3.4.0",
     "jest": "^18.1.0",
+    "jsdoc": "^3.4.0",
     "mkdirp": "^0.5.1"
   },
   "jest": {

--- a/src/Runner.js
+++ b/src/Runner.js
@@ -10,8 +10,6 @@
 
 'use strict';
 
-require('es6-promise').polyfill();
-
 const child_process = require('child_process');
 const colors = require('colors/safe');
 const fs = require('fs');


### PR DESCRIPTION
Promises are native in [all required `node` versions](https://github.com/facebook/jscodeshift/blob/master/package.json#L20).