### PR TITLE
expose Runner and get access to transform results

### DIFF
--- a/src/Collection.js
+++ b/src/Collection.js
@@ -119,6 +119,15 @@ class Collection {
   }
 
   /**
+   * Provides a callback mechanism to be notified when done with previous steps.
+   *
+   * @param {function} callback
+   */
+  done(cb) {
+    return cb.call(this);
+  }
+
+  /**
    * Returns the number of elements in this collection.
    *
    * @return {number}

--- a/src/Runner.js
+++ b/src/Runner.js
@@ -142,6 +142,7 @@ function run(transformFile, paths, options) {
     options.extensions && options.extensions.split(',').map(ext => '.' + ext);
   const fileCounters = {error: 0, ok: 0, nochange: 0, skip: 0};
   const statsCounter = {};
+  const results = [];
   const startTime = process.hrtime();
 
   ignores.add(options.ignorePattern);
@@ -249,6 +250,9 @@ function run(transformFile, paths, options) {
                 }
                 statsCounter[message.name] += message.quantity;
                 break;
+              case 'result': 
+                results.push(message.result);
+                break;
               case 'free':
                 child.send({files: next(), options});
                 break;
@@ -274,6 +278,7 @@ function run(transformFile, paths, options) {
           }
           return Object.assign({
             stats: statsCounter,
+            results: results,
             timeElapsed: timeElapsed
           }, fileCounters);
         })

--- a/src/Worker.js
+++ b/src/Worker.js
@@ -143,6 +143,11 @@ function run(data) {
             callback();
             return;
           }
+          if (options.result) {
+            notify({action: 'result', result: out });
+            callback();
+            return;
+          }
           if (options.print) {
             console.log(out); // eslint-disable-line no-console
           }

--- a/src/__tests__/Collection-test.js
+++ b/src/__tests__/Collection-test.js
@@ -234,6 +234,15 @@ describe('Collection API', function() {
       });
     });
 
+    describe('done', function() {
+      it('lets you get notified with callback', function() {
+        const cb = jest.genMockFunction();
+        Collection.fromNodes(nodes).done(cb);
+
+        expect(cb.mock.calls.length).toBe(1);
+      });
+    });
+
     describe('map', function() {
       it('returns a new collection with mapped values', function() {
         const root = Collection.fromNodes(nodes);

--- a/src/core.js
+++ b/src/core.js
@@ -16,6 +16,7 @@ const getParser = require('./getParser');
 const matchNode = require('./matchNode');
 const recast = require('recast');
 const template = require('./template');
+const run = require('./Runner').run;
 
 const Node = recast.types.namedTypes.Node;
 const NodePath = recast.types.NodePath;
@@ -178,6 +179,7 @@ function enrichCore(core, parser) {
     }
   }
   core.use = use;
+  core.run = run;
   core.withParser = withParser;
   return core;
 }


### PR DESCRIPTION
Access to the runner from the jscodeshift api - so that you can programmatically run jscodeshift ( same as running it from cli ). Currently I am not sure how you can do this without this PR. 

This seems to have been requested before ( #47 ) and perhaps was implemented but seems to have been missed recently ? 