### PR TITLE
template.expression should not parse string without interpolation as statement

### DIFF
--- a/src/__tests__/template-test.js
+++ b/src/__tests__/template-test.js
@@ -111,6 +111,18 @@ while (i < 10) {
     .toEqual(expected);
   });
 
+  it('correctly parses expressions without any interpolation', () => {
+    const expected = 'function() {}';
+
+    expect(
+      jscodeshift(
+        expression`function() {}`
+      )
+      .toSource()
+    )
+    .toEqual(expected);
+  });
+
   describe('explode arrays', () => {
 
     it('explodes arrays in function definitions', () => {

--- a/src/template.js
+++ b/src/template.js
@@ -132,11 +132,9 @@ module.exports = function withParser(parser) {
   function expression(template/*, ...nodes*/) {
     // wrap code in `(...)` to force evaluation as expression
     template = Array.from(template);
-    if (template.length > 1) {
+    if (template.length > 0) {
       template[0] = '(' + template[0];
       template[template.length - 1] += ')';
-    } else if (template.length === 0) {
-      template[0] = '(' + template[0] + ')';
     }
 
     return statement.apply(


### PR DESCRIPTION
Let's parse a function expression with `jscodeshift.template.expression`:
```js
expression`function() {}`
```

This code is a valid expression, but not a valid statement -- a function needs to have a name to be a valid statement.

`template.expression` surrounds the code with `()` to force parsing as expression. However, it fails to do so if the template string doesn't have any interpolation parameters. Therefore, the above function expression fails to parse.

This PR fixes that bug -- the length of the `template` array is incorrectly checked. It should check for `length === 1` instead of `length === 0`. Moreover, a special case for `length === 1` is not even necessary.
