### PR TITLE
Bump recast to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,15 +40,15 @@
     "micromatch": "^2.3.7",
     "node-dir": "0.1.8",
     "nomnom": "^1.8.1",
-    "recast": "^0.11.11",
+    "recast": "^0.12.5",
     "temp": "^0.8.1",
     "write-file-atomic": "^1.2.0"
   },
   "devDependencies": {
     "babel-eslint": "^6.1.2",
     "eslint": "^3.1.1",
-    "jsdoc": "^3.4.0",
     "jest": "^18.1.0",
+    "jsdoc": "^3.4.0",
     "mkdirp": "^0.5.1"
   },
   "jest": {


### PR DESCRIPTION
Tests pass.

This version of recast includes a fix to iife wrapping when using babylon parser.