### PR TITLE
Bump babylon version to latest stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-1": "^6.5.0",
     "babel-register": "^6.9.0",
-    "babylon": "^6.8.1",
+    "babylon": "^6.17.3",
     "colors": "^1.1.2",
     "es6-promise": "^3.0.0",
     "flow-parser": "^0.*",


### PR DESCRIPTION
This version includes https://github.com/babel/babylon/pull/565 which was breaking `recast` on any code with Flow function type params.