### PR TITLE
Fix `renameTo` not taking property shorthands into account

### DIFF
--- a/src/collections/VariableDeclarator.js
+++ b/src/collections/VariableDeclarator.js
@@ -126,6 +126,17 @@ const transformMethods = {
             scope = scope.parent;
           }
           if (scope) { // identifier must refer to declared variable
+
+            const parent = path.parent.node;
+            if (
+              types.Property.check(parent) &&
+              parent.shorthand &&
+              !parent.method
+            )  {
+
+              path.parent.get('shorthand').replace(false);
+            }
+
             path.get('name').replace(newName);
           }
         });

--- a/src/collections/VariableDeclarator.js
+++ b/src/collections/VariableDeclarator.js
@@ -134,7 +134,11 @@ const transformMethods = {
             scope = scope.parent;
           }
           if (scope) { // identifier must refer to declared variable
-
+            
+            // It may look like we filtered out properties, 
+            // but the filter only ignored property "keys", not "value"s
+            // In shorthand properties, "key" and "value" both have an
+            // Identifier with the same structure.
             const parent = path.parent.node;
             if (
               types.Property.check(parent) &&

--- a/src/collections/__tests__/VariableDeclarator-test.js
+++ b/src/collections/__tests__/VariableDeclarator-test.js
@@ -135,7 +135,7 @@ describe('VariableDeclarators', function() {
         'var obj2 = {',
         '  foo,',
         '};',
-      ].join('\n'), {parser: babel}).program];
+      ].join('\n'), {parser: getParser()}).program];
 
       // Outputs:
       // var newFoo = 42;


### PR DESCRIPTION
This fixes the `renameTo` helper method not properly renaming object properties that are shorthands.

Bug reproduction in AST Explorer: http://astexplorer.net/#/gist/0ad1434f08e1720089d7085fbdfe7ba0/6f6632f0bb6e2e3aa77d5e873d0ab05d6c3be0e3

The previous version of the code would rename the property's `value` correctly, but since `shorthand` was still set as `true`, the output result would still be the old variable as a shorthand
property.

Now, if an identifier to be renamed is of type `Property` and is a shorthand (but not a method), we flip the `shorthand` value to be `false`.

Added a test for this as well.