### PR TITLE
Allow specifying a testName for inline tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ This will run two tests: One for `__testfixtures__/FirstFixture.input.js` and on
 #### `defineInlineTest`
 ```js
 const transform = require('../myTransform');
-defineInlineTest(transform, {}, 'input', 'expected output');
+defineInlineTest(transform, {}, 'input', 'expected output', 'test name (optional)');
 ```
 
 ### Example Codemods

--- a/sample/__tests__/reverse-identifiers-test.js
+++ b/sample/__tests__/reverse-identifiers-test.js
@@ -33,4 +33,9 @@ var droWtsrif = 'Hello ';
 var droWdnoces = 'world';
 var egassem = droWtsrif + droWdnoces;
   `);
+  defineInlineTest(transform, {},
+    'function aFunction() {};',
+    'function noitcnuFa() {};',
+    'Reverses function names'
+  );
 });

--- a/src/testUtils.js
+++ b/src/testUtils.js
@@ -93,8 +93,8 @@ function defineTest(dirName, transformName, options, testFilePrefix) {
 }
 exports.defineTest = defineTest;
 
-function defineInlineTest(module, options, input, expectedOutput) {
-  it('transforms correctly', () => {
+function defineInlineTest(module, options, input, expectedOutput, testName) {
+  it(testName || 'transforms correctly', () => {
     runInlineTest(module, options, {
       source: input
     }, expectedOutput);


### PR DESCRIPTION
This is a small change that makes test output a bit nicer when writing
multiple inline tests.