### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,9 @@
 We want to make contributing to this project as easy and transparent as
 possible.
 
+## Code of Conduct
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
+
 ## Our Development Process
 The majority of development on jscodeshift will occur through GitHub. Accordingly,
 the process for contributing will follow standard GitHub protocol.


### PR DESCRIPTION
In the past Facebook didn't promote including a Code of Conduct when creating new projects, and many projects skipped this important document. Let's fix it. :)

**why make this change?:**
Facebook Open Source provides a Code of Conduct statement for all
projects to follow, to promote a welcoming and safe open source community.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will improve [the dataloader community profile](https://github.com/facebook/dataloader/community)
checklist and increase the visibility of our COC.

**test plan:**
Viewing it on my branch -
<img width="1309" alt="screen shot 2017-11-25 at 9 44 50 am" src="https://user-images.githubusercontent.com/1114467/33233067-57625fd4-d1c5-11e7-97a4-90d54cb236ad.png">
<img width="1300" alt="screen shot 2017-11-25 at 9 44 59 am" src="https://user-images.githubusercontent.com/1114467/33233068-57809bc0-d1c5-11e7-8bc4-319cdf06be0e.png">

**issue:**
internal task t23481323