### PR TITLE
Allow transform to be a promise. Resolves #210.

### DIFF
--- a/src/Worker.js
+++ b/src/Worker.js
@@ -117,7 +117,7 @@ function run(data) {
   async.each(
     files,
     function(file, callback) {
-      fs.readFile(file, function(err, source) {
+      fs.readFile(file, async function(err, source) {
         if (err) {
           updateStatus('error', file, 'File error: ' + err);
           callback();
@@ -126,7 +126,7 @@ function run(data) {
         source = source.toString();
         try {
           const jscodeshift = prepareJscodeshift(options);
-          const out = transform(
+          const out = await transform(
             {
               path: file,
               source: source,


### PR DESCRIPTION
Hello. Wanted to float this, as a way to allow transforms to be async. This unlocks any kind of transform that would want to query some exterior piece of state.