### PR TITLE
Guarantee uniqueness of variable names

### DIFF
--- a/src/template.js
+++ b/src/template.js
@@ -103,8 +103,9 @@ function replaceNodes(src, varNames, nodes, parser) {
   return ast;
 }
 
-function getRandomVarName() {
-  return `$jscodeshift${Math.floor(Math.random() * 1000)}$`;
+let varNameCounter = 0;
+function getUniqueVarName() {
+  return `$jscodeshift${varNameCounter++}$`;
 }
 
 
@@ -112,7 +113,7 @@ module.exports = function withParser(parser) {
   function statements(template/*, ...nodes*/) {
     template = Array.from(template);
     const nodes = Array.from(arguments).slice(1);
-    const varNames = nodes.map(() => getRandomVarName());
+    const varNames = nodes.map(() => getUniqueVarName());
     const src = template.reduce(
       (result, elem, i) => result + varNames[i - 1] + elem
     );


### PR DESCRIPTION
The current code causes duplicate variable names due to there being no guarantee that `Math.random()` will return non-colliding values. This is especially true given the 32-bits of the V8 `Math.random()` implementation.

This change replaces the use of `Math.random()` with a simple counter to guarantee that each name returned is different.