### PR TITLE
Fix error handling for http

### DIFF
--- a/src/Runner.js
+++ b/src/Runner.js
@@ -157,17 +157,19 @@ function run(transformFile, paths, options) {
           })
           .on('end', () => {
             temp.open('jscodeshift', (err, info) => {
-              reject(err);
-              fs.write(info.fd, contents);
-              fs.close(info.fd, function(err) {
-                reject(err);
-                transform(info.path).then(resolve, reject);
+              if (err) return reject(err);
+              fs.write(info.fd, contents, function (err) {
+                if (err) return reject(err);
+                fs.close(info.fd, function(err) {
+                  if (err) return reject(err);
+                  transform(info.path).then(resolve, reject);
+                });
               });
             });
         })
       })
       .on('error', (e) => {
-        reject(e.message);
+        reject(e);
       });
     });
   } else if (!fs.existsSync(transformFile)) {


### PR DESCRIPTION
The reject handler were always called no matter if there was an or not.

Now it will properly test for that and also wait for the write to be done before closing fd.

It will also report an error including a stack trace from now on and not only show a error message in case there is an error in the http(s) call.

I also fixed the issue that the write did not have a callback at all, so that error was always silent so far. This is going to throw from Node.js 10.x on. See https://github.com/nodejs/node/pull/18668.