### PR TITLE
Enable parsing `?.`, `??`, and numeric separators

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-1": "^6.5.0",
     "babel-register": "^6.9.0",
-    "babylon": "^7.0.0-beta.30",
+    "babylon": "^7.0.0-beta.47",
     "colors": "^1.1.2",
     "flow-parser": "^0.*",
     "lodash": "^4.13.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "neo-async": "^2.5.0",
     "node-dir": "0.1.8",
     "nomnom": "^1.8.1",
-    "recast": "^0.14.1",
+    "recast": "^0.15.0",
     "temp": "^0.8.1",
     "write-file-atomic": "^1.2.0"
   },

--- a/parser/babel5Compat.js
+++ b/parser/babel5Compat.js
@@ -31,6 +31,8 @@ const options = {
     'functionSent',
     'objectRestSpread',
     'dynamicImport',
+    'nullishCoalescingOperator',
+    'optionalChaining',
   ],
 };
 

--- a/parser/babylon.js
+++ b/parser/babylon.js
@@ -32,6 +32,8 @@ const options = {
     'functionBind',
     'functionSent',
     'dynamicImport',
+    'nullishCoalescingOperator',
+    'optionalChaining',
   ],
 };
 

--- a/parser/babylon.js
+++ b/parser/babylon.js
@@ -34,6 +34,7 @@ const options = {
     'dynamicImport',
     'nullishCoalescingOperator',
     'optionalChaining',
+    'numericSeparator',
   ],
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -129,9 +129,9 @@ assert-plus@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
 
-ast-types@0.11.1:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.11.1.tgz#5bb3a8d5ba292c3f4ae94d46df37afc30300b990"
+ast-types@0.11.5:
+  version "0.11.5"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.11.5.tgz#9890825d660c03c28339f315e9fa0a360e31ec28"
 
 async@^1.4.0:
   version "1.5.2"
@@ -2568,11 +2568,11 @@ readline2@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     mute-stream "0.0.5"
 
-recast@^0.14.1:
-  version "0.14.1"
-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.14.1.tgz#959ea20d7cb970bea1ec059325b8bdaf0738b788"
+recast@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.15.0.tgz#b8c8bfdda245e1580c0a4d9fc25d4e820bf57208"
   dependencies:
-    ast-types "0.11.1"
+    ast-types "0.11.5"
     esprima "~4.0.0"
     private "~0.1.5"
     source-map "~0.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -776,9 +776,9 @@ babylon@^6.0.18, babylon@^6.13.0, babylon@^6.17.2:
   version "6.17.3"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.3.tgz#1327d709950b558f204e5352587fd0290f8d8e48"
 
-babylon@^7.0.0-beta.30:
-  version "7.0.0-beta.40"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.40.tgz#91fc8cd56d5eb98b28e6fde41045f2957779940a"
+babylon@^7.0.0-beta.47:
+  version "7.0.0-beta.47"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.47.tgz#6d1fa44f0abec41ab7c780481e62fd9aafbdea80"
 
 balanced-match@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This enables 
- the `a?.b` optional chaining operator
- the `a ?? b` nullish coalescing operator
- the `12__32__43` numerical separators syntax