### PR TITLE
PARTIAL FIX - Replace Nomnom with Commander - Looking for feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ additional options to the transform. For example, if the CLI is called with
 $ jscodeshift -t myTransforms fileA fileB --foo=bar
 ```
 
-`options` would contain `{foo: 'bar'}`. jscodeshift uses [nomnom][] to parse
+`options` would contain `{foo: 'bar'}`. jscodeshift uses [commander][] to parse
 command line options.
 
 ### Return value
@@ -140,11 +140,11 @@ You can collect even more stats via the `stats` function as explained above.
 
 ### Parser
 
-The transform can let jscodeshift know with which parser to parse the source 
+The transform can let jscodeshift know with which parser to parse the source
 files (and features like templates).
 
-To do that, the transform module can export `parser`, which can either be one 
-of the strings `"babel"`, `"babylon"`, or `"flow"`, or it can be a parser 
+To do that, the transform module can export `parser`, which can either be one
+of the strings `"babel"`, `"babylon"`, or `"flow"`, or it can be a parser
 object that is compatible with recast.
 
 For example:
@@ -317,7 +317,7 @@ This can be done by passing config options to [recast].
 .toSource({quote: 'single'}); // sets strings to use single quotes in transformed code.
 ```
 
-You can also pass options to recast's `parse` method by passing an object to 
+You can also pass options to recast's `parse` method by passing an object to
 jscodeshift as second argument:
 
 ```js
@@ -382,4 +382,4 @@ defineInlineTest(transform, {}, 'input', 'expected output', 'test name (optional
 [recast]: https://github.com/benjamn/recast
 [ast-types]: https://github.com/benjamn/ast-types
 [ast-explorer]: http://astexplorer.net/
-[nomnom]: https://www.npmjs.com/package/nomnom
+[commander]: https://www.npmjs.com/package/commander

--- a/bin/__tests__/jscodeshift-test.js
+++ b/bin/__tests__/jscodeshift-test.js
@@ -299,5 +299,5 @@ describe('jscodeshift CLI', () => {
         }
       );
     });
-  })
+  });
 });

--- a/bin/jscodeshift.sh
+++ b/bin/jscodeshift.sh
@@ -16,7 +16,6 @@ const list = function(val, memo) {
   return memo;
 }
 
-
 const Runner = require('../src/Runner.js');
 
 const path = require('path');
@@ -33,6 +32,7 @@ const opts = require('commander')
     ].join('\n');
   })
   //.command('jscodeshift')
+  //.allowUnknownOption()
   .arguments('<FILE...>')
   .option('-t, --transform <FILE>', 'Path to the transform file. Can be either a local path or url', './transform.js')
   .option('-c, --cpus <num>', '(all by default) Determines the number of processes started.')

--- a/bin/jscodeshift.sh
+++ b/bin/jscodeshift.sh
@@ -11,104 +11,46 @@
 
 'use strict';
 
+const list = function(val, memo) {
+  memo.push(val);
+  return memo;
+}
+
+
 const Runner = require('../src/Runner.js');
 
 const path = require('path');
 const pkg = require('../package.json');
-const opts = require('nomnom')
-  .script('jscodeshift')
-  .options({
-    path: {
-      position: 0,
-      help: 'Files or directory to transform',
-      list: true,
-      metavar: 'FILE',
-      required: true
-    },
-    transform: {
-      abbr: 't',
-      default: './transform.js',
-      help: 'Path to the transform file. Can be either a local path or url',
-      metavar: 'FILE'
-    },
-    cpus: {
-      abbr: 'c',
-      help: '(all by default) Determines the number of processes started.'
-    },
-    verbose: {
-      abbr: 'v',
-      choices: [0, 1, 2],
-      default: 0,
-      help: 'Show more information about the transform process'
-    },
-    dry: {
-      abbr: 'd',
-      flag: true,
-      help: 'Dry run (no changes are made to files)'
-    },
-    print: {
-      abbr: 'p',
-      flag: true,
-      help: 'Print output, useful for development'
-    },
-    babel: {
-      flag: true,
-      default: true,
-      help: 'Apply Babel to transform files'
-    },
-    extensions: {
-      default: 'js',
-      help: 'File extensions the transform file should be applied to'
-    },
-    ignorePattern: {
-      full: 'ignore-pattern',
-      list: true,
-      help: 'Ignore files that match a provided glob expression'
-    },
-    ignoreConfig: {
-      full: 'ignore-config',
-      list: true,
-      help: 'Ignore files if they match patterns sourced from a configuration file (e.g., a .gitignore)',
-      metavar: 'FILE'
-    },
-    runInBand: {
-      flag: true,
-      default: false,
-      full: 'run-in-band',
-      help: 'Run serially in the current process'
-    },
-    silent: {
-      abbr: 's',
-      flag: true,
-      default: false,
-      full: 'silent',
-      help: 'No output'
-    },
-    parser: {
-      choices: ['babel', 'babylon', 'flow'],
-      default: 'babel',
-      full: 'parser',
-      help: 'The parser to use for parsing your source files (babel | babylon | flow)'
-    },
-    version: {
-      flag: true,
-      help: 'print version and exit',
-      callback: function() {
-        const requirePackage = require('../utils/requirePackage');
-        return [
-          `jscodeshift: ${pkg.version}`,
-          ` - babel: ${require('babel-core').version}`,
-          ` - babylon: ${requirePackage('babylon').version}`,
-          ` - flow: ${requirePackage('flow-parser').version}`,
-          ` - recast: ${requirePackage('recast').version}`,
-        ].join('\n');
-      },
-    },
+const opts = require('commander')
+  .version(function() {
+    const requirePackage = require('../utils/requirePackage');
+    return [
+      `jscodeshift: ${pkg.version}`,
+      ` - babel: ${require('babel-core').version}`,
+      ` - babylon: ${requirePackage('babylon').version}`,
+      ` - flow: ${requirePackage('flow-parser').version}`,
+      ` - recast: ${requirePackage('recast').version}`,
+    ].join('\n');
   })
-  .parse();
+  //.command('jscodeshift')
+  .arguments('<FILE...>')
+  .option('-t, --transform <FILE>', 'Path to the transform file. Can be either a local path or url', './transform.js')
+  .option('-c, --cpus <num>', '(all by default) Determines the number of processes started.')
+  .option('-v, --verbose [level]', 'Show more information about the transform process', /^(0|1|2)$/i, 0)
+  .option('-d, --dry', 'Dry run (no changes are made to files)', false)
+  .option('-p, --print', 'Print output, useful for development', false)
+  .option('--babel', 'Apply Babel to transform files')
+  .option('--no-babel', 'Do not apply Babel to transform files')
+  .option('--extensions <extensions>', 'File extensions the transform file should be applied to', 'js')
+  .option('--ignore-pattern <pattern>', 'Ignore files that match a provided glob expression', list, [])
+  .option('--ignore-config <FILE>',  'Ignore files if they match patterns sourced from a configuration file (e.g., a .gitignore)', list, [])
+  .option('--run-in-band', 'Run serially in the current process', 'false') // Might need false default
+  .option('-s, --silent',  'No output', false)
+  .option('--parser', 'The parser to use for parsing your source files (babel | babylon | flow)', /^(babel|babylon|flow)$/, 'babel')
+  .parse(process.argv);
 
 Runner.run(
-  /^https?/.test(opts.transform) ? opts.transform : path.resolve(opts.transform), 
-  opts.path,
+  /^https?/.test(opts.transform) ? opts.transform : path.resolve(opts.transform),
+  opts.args,
   opts
 );

--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
     "babel-register": "^6.9.0",
     "babylon": "^7.0.0-beta.47",
     "colors": "^1.1.2",
+    "commander": "^2.15.1",
     "flow-parser": "^0.*",
     "lodash": "^4.13.1",
     "micromatch": "^2.3.7",
     "neo-async": "^2.5.0",
     "node-dir": "0.1.8",
-    "nomnom": "^1.8.1",
     "recast": "^0.15.0",
     "temp": "^0.8.1",
     "write-file-atomic": "^1.2.0"

--- a/src/Runner.js
+++ b/src/Runner.js
@@ -128,7 +128,7 @@ function getAllFiles(paths, filter) {
         } else {
           resolve([file]);
         }
-      })
+      });
     }))
   ).then(concatAll);
 }


### PR DESCRIPTION
Looking for help on this one. I have replaced `nomnom` with `commander` and the tests pass with the exception of one: `jscodeshift CLI › passes options along to the transform`.

Commander doesn't support arbitrary args, like nomnom, so it can't pass them along.

I did some quick looking and didn't find a good alternative.