### PR TITLE
Enable more flow parser options

### DIFF
--- a/parser/flow.js
+++ b/parser/flow.js
@@ -18,6 +18,7 @@ const options = {
   esproposal_decorators: true,
   esproposal_export_star_as: true,
   esproposal_optional_chaining: true,
+  esproposal_nullish_coalescing: true,
   token: true,
   types: true,
 };

--- a/parser/flow.js
+++ b/parser/flow.js
@@ -17,6 +17,8 @@ const options = {
   esproposal_class_static_fields: true,
   esproposal_decorators: true,
   esproposal_export_star_as: true,
+  esproposal_optional_chaining: true,
+  token: true,
   types: true,
 };
 


### PR DESCRIPTION
`tokens` is an undocumented flag that adds the tokens to the output ast.
https://github.com/facebook/flow/blob/master/src/parser/libflowparser.ml#L60

This is necessary for the newest version of recast, which will use the esprima parser if the tokens aren't present: https://github.com/benjamn/recast/blob/master/lib/parser.js#L44-L48. The esprima parser doesn't parse JSX, which makes running jscodeshift on files with jsx in them fail when relying on the new version of recast. To repro, update the recast version and run a codemod on a file with JSX-- you will get a parse error.

It will be necessary to upgrade the recast dependency in order to support the new `...` syntax for flow inexact objects.

Is there a reason not to include all of the proposal parsers? I enabled optional chaining and nullish coalescing because the rest were enabled.