### PR TITLE
Add support for explicit flow type arguments

### DIFF
--- a/bin/jscodeshift.sh
+++ b/bin/jscodeshift.sh
@@ -98,7 +98,7 @@ const opts = require('nomnom')
         return [
           `jscodeshift: ${pkg.version}`,
           ` - babel: ${require('babel-core').version}`,
-          ` - babylon: ${requirePackage('babylon').version}`,
+          ` - babylon: ${requirePackage('@babel/parser').version}`,
           ` - flow: ${requirePackage('flow-parser').version}`,
           ` - recast: ${requirePackage('recast').version}`,
         ].join('\n');
@@ -108,7 +108,7 @@ const opts = require('nomnom')
   .parse();
 
 Runner.run(
-  /^https?/.test(opts.transform) ? opts.transform : path.resolve(opts.transform), 
+  /^https?/.test(opts.transform) ? opts.transform : path.resolve(opts.transform),
   opts.path,
   opts
 );

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-1": "^6.5.0",
     "babel-register": "^6.9.0",
-    "babylon": "^7.0.0-beta.47",
+    "@babel/parser": "^7.0.0o",
     "colors": "^1.1.2",
     "flow-parser": "^0.*",
     "lodash": "^4.13.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-1": "^6.5.0",
     "babel-register": "^6.9.0",
-    "@babel/parser": "^7.0.0o",
+    "@babel/parser": "^7.0.0",
     "colors": "^1.1.2",
     "flow-parser": "^0.*",
     "lodash": "^4.13.1",

--- a/parser/babel5Compat.js
+++ b/parser/babel5Compat.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const babylon = require('babylon');
+const babylon = require('@babel/parser');
 
 // These are the options that were the default of the Babel5 parse function
 // see https://github.com/babel/babel/blob/5.x/packages/babel/src/api/node.js#L81

--- a/parser/babylon.js
+++ b/parser/babylon.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const babylon = require('babylon');
+const babylon = require('@babel/parser');
 
 const options = {
   sourceType: 'module',
@@ -18,13 +18,13 @@ const options = {
   allowReturnOutsideFunction: true,
   plugins: [
     'jsx',
-    'flow',
+    ['flow': {all: true}],
     'asyncFunctions',
     'classConstructorCall',
     'doExpressions',
     'trailingFunctionCommas',
     'objectRestSpread',
-    'decorators',
+    ['decorators', {decoratorsBeforeExport: false, legacy: true}],
     'classProperties',
     'exportExtensions',
     'exponentiationOperator',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@babel/parser@^7.0.0o":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.1.3.tgz#2c92469bac2b7fbff810b67fca07bd138b48af77"
+  integrity sha512-gqmspPZOMW3MIRb9HlrnbZHXI1/KHTOroBwN1NcLL6pWxzqzEKGvRTq0W/PxS45OtQGbaFikSQpkS5zbnsQm2w==
+
 abab@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.3.tgz#b81de5f7274ec4e756d797cd834f303642724e5d"
@@ -776,10 +781,6 @@ babylon@^6.0.18, babylon@^6.13.0, babylon@^6.17.2:
   version "6.17.3"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.3.tgz#1327d709950b558f204e5352587fd0290f8d8e48"
 
-babylon@^7.0.0-beta.47:
-  version "7.0.0-beta.47"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.47.tgz#6d1fa44f0abec41ab7c780481e62fd9aafbdea80"
-
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -1375,8 +1376,9 @@ flat-cache@^1.2.1:
     write "^0.2.1"
 
 flow-parser@^0.*:
-  version "0.47.0"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.47.0.tgz#c57d35ff19bb40fb0f07222298e58cd4afa8a59a"
+  version "0.85.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.85.0.tgz#b43b684295eb0d79a34048c14501d2ef35f48c0f"
+  integrity sha512-oMmkfBX/ku7j9KCiog0tP7e0hFou5cZM/RywCOluioz10ZC9b0dFjxrkVscUHgKcQfz2i39EtnUKkm9M8Qo+Fg==
 
 for-in@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
In order to support explicit flow type arguments, this PR upgrades the babylon parser from babylon 6 to @babel/parser ^7.0.0.

Example of new syntax:
```js
// @flow
const a = b<stirng>();
```