### PR TITLE
SyntaxError-Using-the-export-keyword-between-a-decorator-and-a-class-…

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "babel-plugin-transform-flow-strip-types": "^6.8.0",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-1": "^6.5.0",
     "babel-register": "^6.9.0",

--- a/parser/babel5Compat.js
+++ b/parser/babel5Compat.js
@@ -23,6 +23,7 @@ const options = {
   plugins: [
     'estree',
     'jsx',
+    'decorators-legacy',
     'asyncGenerators',
     'classProperties',
     'doExpressions',
@@ -33,7 +34,9 @@ const options = {
     'dynamicImport',
     'nullishCoalescingOperator',
     'optionalChaining',
-  ],
+    'exportDefaultFrom',
+    'exportNamespaceFrom',
+  ]
 };
 
 /**


### PR DESCRIPTION
SyntaxError: Using the export keyword between a decorator and a class is not allowed. Please use `export @dec class` instead 
support for legacy decorators