### PR TITLE
Add parsers for TypeScript and TSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Options:
    --ignore-config FILE        Ignore files if they match patterns sourced from a configuration file (e.g., a .gitignore)
    --run-in-band               Run serially in the current process  [false]
    -s, --silent                No output  [false]
-   --parser                    The parser to use for parsing your source files (babel | babylon | flow)  [babel]
+   --parser                    The parser to use for parsing your source files (babel | babylon | flow | ts | tsx)  [babel]
    --version                   print version and exit
 ```
 
@@ -144,8 +144,8 @@ The transform can let jscodeshift know with which parser to parse the source
 files (and features like templates).
 
 To do that, the transform module can export `parser`, which can either be one 
-of the strings `"babel"`, `"babylon"`, or `"flow"`, or it can be a parser 
-object that is compatible with recast.
+of the strings `"babel"`, `"babylon"`, `"flow"`, `"ts"`, or `"tsx"`,
+or it can be a parser object that is compatible with recast.
 
 For example:
 

--- a/bin/jscodeshift.sh
+++ b/bin/jscodeshift.sh
@@ -85,10 +85,10 @@ const opts = require('nomnom')
       help: 'No output'
     },
     parser: {
-      choices: ['babel', 'babylon', 'flow'],
+      choices: ['babel', 'babylon', 'flow', 'ts', 'tsx'],
       default: 'babel',
       full: 'parser',
-      help: 'The parser to use for parsing your source files (babel | babylon | flow)'
+      help: 'The parser to use for parsing your source files (babel | babylon | flow | ts | tsx)'
     },
     version: {
       flag: true,

--- a/parser/ts.js
+++ b/parser/ts.js
@@ -1,0 +1,18 @@
+/*
+ *  Copyright (c) 2015-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+'use strict';
+
+const babylon = require('babylon');
+const options = require('./tsOptions');
+
+exports.parse = function parse (code) {
+  return babylon.parse(code, options);
+};

--- a/parser/tsOptions.js
+++ b/parser/tsOptions.js
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2015-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+'use strict';
+
+/**
+ * Options shared by the TypeScript and TSX parsers.
+ */
+module.exports = {
+  sourceType: 'module',
+  allowImportExportEverywhere: true,
+  allowReturnOutsideFunction: true,
+  plugins: [
+    'asyncGenerators',
+    'bigInt',
+    'classPrivateMethods',
+    'classPrivateProperties',
+    'classProperties',
+    'decorators-legacy',
+    'doExpressions',
+    'dynamicImport',
+    'exportDefaultFrom',
+    'exportExtensions',
+    'exportNamespaceFrom',
+    'functionBind',
+    'functionSent',
+    'importMeta',
+    'nullishCoalescingOperator',
+    'numericSeparator',
+    'objectRestSpread',
+    'optionalCatchBinding',
+    'optionalChaining',
+    ['pipelineOperator', { proposal: 'minimal' }],
+    'throwExpressions',
+    'typescript'
+  ],
+};

--- a/parser/tsx.js
+++ b/parser/tsx.js
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (c) 2015-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+'use strict';
+
+const _ = require('lodash');
+const babylon = require('babylon');
+const baseOptions = require('./tsOptions');
+
+const options = _.merge(baseOptions, { plugins: ['jsx'] });
+
+exports.parse = function parse (code) {
+  return babylon.parse(code, options);
+};

--- a/src/getParser.js
+++ b/src/getParser.js
@@ -16,6 +16,10 @@ module.exports = function getParser(parserName) {
       return require('../parser/babylon');
     case 'flow':
       return require('../parser/flow');
+    case 'ts':
+      return require('../parser/ts');
+    case 'tsx':
+      return require('../parser/tsx');
     case 'babel':
     default:
       return require('../parser/babel5Compat');


### PR DESCRIPTION
Add parsers for TypeScript and TSX to make it easier to use jscodeshift for TypeScript projects.

Babel options were taken from https://github.com/benjamn/recast/blob/master/parsers/_babel_options.js

A separate parser for TSX was added because there are language constructs that have a different meaning depending on whether the file is TSX or not, such as `<type>` syntax for casting (which was mentioned here https://github.com/benjamn/recast/pull/535).

Example Usage:
```
jscodeshift -t sample/reverse-identifiers.js --extensions ts,tsx --parser tsx all-the-code
```

Reviewers: @fkling @cpojer 
cc @benjamn