### PR TITLE
Bump recast to ^0.16.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "neo-async": "^2.5.0",
     "node-dir": "0.1.8",
     "nomnom": "^1.8.1",
-    "recast": "^0.15.0",
+    "recast": "^0.16.1",
     "temp": "^0.8.1",
     "write-file-atomic": "^1.2.0"
   },


### PR DESCRIPTION
See diff here: https://github.com/benjamn/recast/compare/v0.15.5...v0.16.1

Notably, this includes some bugfixes for type support.

to: @brieb @fkling 