### PR TITLE
Use @babel/parser in TypeScript parser

### DIFF
--- a/bin/__tests__/jscodeshift-test.js
+++ b/bin/__tests__/jscodeshift-test.js
@@ -321,7 +321,27 @@ describe('jscodeshift CLI', () => {
         }
       );
     });
-  })
+  });
+
+  describe('--parser=ts', () => {
+    it('parses TypeScript sources', () => {
+      const source = createTempFileWith('type Foo = string | string[];');
+      const transform = createTransformWith(
+        'api.jscodeshift(fileInfo.source)\nreturn "changed";'
+      );
+      return run([
+        '-t', transform,
+        '--parser', 'ts',
+        '--run-in-band',
+        source,
+      ]).then(
+        out => {
+          expect(out[0]).not.toContain('Transformation error');
+          expect(readFile(source)).toEqual('changed');
+        }
+      );
+    });
+  });
 
   describe('--parser-config', () => {
     it('allows custom parser settings to be passed', () => {

--- a/parser/ts.js
+++ b/parser/ts.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const babylon = require('babylon');
+const babylon = require('@babel/parser');
 const options = require('./tsOptions');
 
 /**

--- a/parser/tsx.js
+++ b/parser/tsx.js
@@ -11,7 +11,7 @@
 'use strict';
 
 const _ = require('lodash');
-const babylon = require('babylon');
+const babylon = require('@babel/parser');
 const baseOptions = require('./tsOptions');
 
 const options = _.merge(baseOptions, { plugins: ['jsx'] });


### PR DESCRIPTION
Previously, the TypeScript parser would fail due to the 'babylon' package having the incorrect version (v6). Added a test which will detect this:

```
  ● jscodeshift CLI › --parser=ts › parses TypeScript sources

    expect(string).not.toContain(value)

    Expected string:
      "Processing 1 files...
     ERR /var/folders/ms/t3l222rn1v3dkvvnytj4vfkw0000gn/T/f-118113-6659-hurec.taoyh Transformation error (Unexpected token, expected ; (1:5))
    SyntaxError: Unexpected token, expected ; (1:5)
```

Switching to '@babel/parser' fixes this.