### PR TITLE
Fix TypeError in case no files were found

### DIFF
--- a/src/Runner.js
+++ b/src/Runner.js
@@ -218,7 +218,7 @@ function run(transformFile, paths, options) {
 
         if (numFiles === 0) {
           process.stdout.write('No files selected, nothing to do. \n');
-          return;
+          return [];
         }
 
         const processes = options.runInBand ? 1 : Math.min(numFiles, cpus);


### PR DESCRIPTION
In case no files are found then jscodeshift crashes with a `TypeError` as `pendingWorkers` are `undefined`, so `Promise.all(pendingWorkers)` will fail.

Output before this PR:
```
No files selected, nothing to do. 
(node:56389) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'Symbol(Symbol.iterator)' of undefined
    at Function.all (<anonymous>)
    at getAllFiles.then.then.pendingWorkers (/node_modules/jscodeshift/src/Runner.js:292:17)
(node:56389) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 3)
(node:56389) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

After this PR the output looks as expected:
```
No files selected, nothing to do. 
All done. 
Results: 
0 errors
0 unmodified
0 skipped
0 ok
```

### Alternatives

I was considering if we should simply do a `process.exit`, but that wouldn't work if people use jscodeshift directly as a node dependency. I think the proposed solution here is the simplest for now.