### PR TITLE
bugfix: Avoid crash when there are no matching files

### DIFF
--- a/src/Runner.js
+++ b/src/Runner.js
@@ -218,7 +218,7 @@ function run(transformFile, paths, options) {
 
         if (numFiles === 0) {
           process.stdout.write('No files selected, nothing to do. \n');
-          return;
+          return [];
         }
 
         const processes = options.runInBand ? 1 : Math.min(numFiles, cpus);


### PR DESCRIPTION
Currently in the case of no files, the first promise of the runner returns undefined, however this leads to a `Cannot read property 'Symbol(Symbol.iterator)' of undefined` when you pass that undefined value into `Promise.all(pendingWorkers)`.

The simple fix here is to return an empty array instead here so that `Promise.all([])` doesn't crash.

Node version: v8.9.1

Before:
![image](https://user-images.githubusercontent.com/1612134/51000699-d6868e00-14fb-11e9-8de5-8cccd48cd630.png)


After:
![image](https://user-images.githubusercontent.com/1612134/51000676-ca023580-14fb-11e9-9f75-6dd368a7c361.png)
