### PR TITLE
Improve handling of .gitignore files.

### DIFF
--- a/src/ignoreFiles.js
+++ b/src/ignoreFiles.js
@@ -12,7 +12,7 @@ const matchers = [];
  * @see {@linkplain https://git-scm.com/docs/gitignore#_pattern_format}
  */
 function addIgnorePattern(val) {
-  if (val && typeof val === 'string') {
+  if (val && typeof val === 'string' && val[0] !== '#') {
     let pattern = val;
     if (pattern.indexOf('/') === -1) {
       matchers.push('**/' + pattern);
@@ -51,7 +51,7 @@ function addIgnoreFromFile(input) {
     const stats = fs.statSync(config);
     if (stats.isFile()) {
       const content = fs.readFileSync(config, 'utf8');
-      lines = lines.concat(content.split('\n'));
+      lines = lines.concat(content.split(/\r?\n/));
     }
   });
 


### PR DESCRIPTION
I tried to use jscodeshift in a repo that had a .gitignore that used `\r\n` as the newline character, and it crashed inside of snapdragon (used by minimatch) because all of the file globs had trailing `\r`s.

This PR cleans up trailing `\r`s and also prevents .gitignore comments from being treated as globs.