### PR TITLE
Remove transform file .js restriction for testUtils

### DIFF
--- a/src/testUtils.js
+++ b/src/testUtils.js
@@ -69,7 +69,7 @@ function runTest(dirName, transformName, options, testFilePrefix) {
     'utf8'
   );
   // Assumes transform is one level up from __tests__ directory
-  const module = require(path.join(dirName, '..', transformName + '.js'));
+  const module = require(path.join(dirName, '..', transformName));
   runInlineTest(module, options, {
     path: inputPath,
     source


### PR DESCRIPTION
Since we are able to write transformers in TS, the .js extension hard coded in testUtils not allow us to use it to write tests for TS transform modules.
And `require('some-module')` will automatically infer some-module's extension whether it is ended with '.js' or '.ts', it should be safe to remove ',js'.