### PR TITLE
support change default parser in fromSource

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -81,6 +81,9 @@ function fromSource(source, options) {
   if (!options.parser) {
     options.parser = getParser();
   }
+  if (typeof options.parser === 'string') {
+    options.parser = getParser(options.parser);
+  }
   return fromAST(recast.parse(source, options));
 }
 


### PR DESCRIPTION
file: core.js
method: fromSource

jscodeshift has many different parsers with useful plugins, but the fromSource method cannot use it .
It's a bother thing to define my own plugin collections for development. so support it.