### PR TITLE
Use canonical capitalization of TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # jscodeshift [![Build Status](https://travis-ci.org/facebook/jscodeshift.svg?branch=master)](https://travis-ci.org/facebook/jscodeshift)
 
 jscodeshift is a toolkit for running codemods over multiple JavaScript or 
-Typescript files.
+TypeScript files.
 It provides:
 
 - A runner, which executes the provided transform for each file passed to it.
@@ -85,7 +85,7 @@ module.exports = function(fileInfo, api, options) {
 };
 ```
 
-As of v0.6.1, this module can also be written in Typescript.
+As of v0.6.1, this module can also be written in TypeScript.
 
 ### Arguments
 


### PR DESCRIPTION
This PR updates "Typescript" &rarr; "TypeScript" in README file.