### PR TITLE
fix: preserve file extension for remote file

### DIFF
--- a/src/Runner.js
+++ b/src/Runner.js
@@ -184,7 +184,8 @@ function run(transformFile, paths, options) {
             contents += d.toString();
           })
           .on('end', () => {
-            temp.open('jscodeshift', (err, info) => {
+            const ext = path.extname(transformFile);
+            temp.open({ prefix: 'jscodeshift', suffix: ext }, (err, info) => {
               if (err) return reject(err);
               fs.write(info.fd, contents, function (err) {
                 if (err) return reject(err);


### PR DESCRIPTION
There is behavior in this program that depends on the extension
of the transformFile, notably how babel runs (or doesn't).

There was a bug when requesting a remote transformFile authored as
an ES6 module because of the temp filename being used.

This commit preserves the original file extension used when writing
the remote file to the temp one.

Fixes https://github.com/facebook/jscodeshift/issues/316