### PR TITLE
Support different parsers in the test utils

### DIFF
--- a/sample/__testfixtures__/typescript/reverse-identifiers.input.ts
+++ b/sample/__testfixtures__/typescript/reverse-identifiers.input.ts
@@ -1,0 +1,5 @@
+const firstWord = 'Hello ';
+const secondWord = 'world';
+const message = firstWord + secondWord;
+
+const getMessage = (): string => message

--- a/sample/__testfixtures__/typescript/reverse-identifiers.output.ts
+++ b/sample/__testfixtures__/typescript/reverse-identifiers.output.ts
@@ -1,0 +1,5 @@
+const droWtsrif = 'Hello ';
+const droWdnoces = 'world';
+const egassem = droWtsrif + droWdnoces;
+
+const egasseMteg = (): string => egassem

--- a/sample/__tests__/reverse-identifiers-test.js
+++ b/sample/__tests__/reverse-identifiers-test.js
@@ -22,6 +22,8 @@ const transform = require('../reverse-identifiers');
 
 defineTest(__dirname, 'reverse-identifiers');
 
+defineTest(__dirname, 'reverse-identifiers', null, 'typescript/reverse-identifiers', { parser: 'ts' });
+
 describe('reverse-identifiers', () => {
   defineInlineTest(transform, {}, `
 var firstWord = 'Hello ';


### PR DESCRIPTION
## Motivation

`jscodeshift` now supports TypeScript (and other parsers) via the CLI. The `react-codemod` package can now support different React codebases. 

## Changes

In order to use the `defineTest` helper in `testUtils.js` with different parsers the `defineTest` function needs to allow dynamic parsers and look at different extensions (for TypeScript: `.ts`, `.tsx`).

The approach used in this PR was to add another parameter `testOptions` that allows passing in an object with a `parser` key. The extension then can be inferred from the file being parsed.

I didn't feel great about adding another parameter so I opted for an object so if there are additional config options they can be added to this object rather than adding more arguments and passing many `null`s to get to the proper position. I also considered folding `testFilePrefix` into this object:

```typescript
{
  testFilePrefix?: string;
  parser?: "flow" | "ts" | "tsx" | ...;
}
``` 

However, this would be a breaking change for those using the `testUtils`. I'm happy to make that change but opted for avoiding the breaking change.

I also originally experiment with reusing the second existing `options` parameter but that's what get's passed to the transformer and it felt like mixing two unrelated option configs. Open to feedback on this approach. See the proposed pull request in `react-codemod` for how this helper would be used and the overall motivation for this change: https://github.com/reactjs/react-codemod/pull/228

## Testing

- See the new TypeScript sample added (in the `sample` directory)