### PR TITLE
Fix Unhandled Promise rejection when called with a non-existent path

### DIFF
--- a/src/Runner.js
+++ b/src/Runner.js
@@ -141,7 +141,7 @@ function getAllFiles(paths, filter) {
       fs.lstat(file, (err, stat) => {
         if (err) {
           process.stderr.write('Skipping path ' + file + ' which does not exist. \n');
-          resolve();
+          resolve([]);
           return;
         }
 


### PR DESCRIPTION
When jscodeshift is called with a path that doesn't exist, `concatAll()` gets called with `undefined`, which isn't an iterable, and throws an error. This PR fixes the promise being resolved by matching it with the ignore case.