### PR TITLE
fix: make Runner's concatAll safer

### DIFF
--- a/src/Runner.js
+++ b/src/Runner.js
@@ -67,8 +67,10 @@ function report({file, msg}) {
 function concatAll(arrays) {
   const result = [];
   for (const array of arrays) {
-    for (const element of array) {
-      result.push(element);
+    if (array) {
+      for (const element of array) {
+        result.push(element);
+      }
     }
   }
   return result;


### PR DESCRIPTION
I have noticed that in some cases the `concatAll` function in `Runner.js` results in errors. Looks like the function assumes a fully populated nested array, whereas the code that generates the nested array with which this function is called can actually result in `undefined` nested items by resolving the promise with nothing here:
https://github.com/facebook/jscodeshift/blob/d63aa8486c2099a65b071e7c86e9dccdb8577d80/src/Runner.js#L142

If it is intentional to throw an error in this case rather than proceeding, I would at least prefer if such errors were handled more gracefully, as I saw no indication as to the root cause in the logs or stack trace when this occurred.

Alternatively, we could change the `resolve()` to `resolve([])`, as is done below it.

Let me know if we should add unit tests to cover this possibility and prove this works - I just wanted to raise a minimal PR to clearly demonstrate the change in functionality to start.
