### PR TITLE
Bump flow parser and jscodeshift version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] 2019-12-11
+### Changed
+- Moved from BSD to MIT license
+
+### Fixed
+- No longer throw an error when calling jscodeshift on a non-existent path (#334, @threepointone)
+- Preserve the original file extension in remote files (#317, @samselikoff)
+
 ## [0.6.4] 2019-04-30
 ### Changed
 - Allow writing tests in TypeScript ([PR #308](https://github.com/facebook/jscodeshift/pull/308))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jscodeshift",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "description": "A toolkit for JavaScript codemods",
   "repository": {
     "type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1918,9 +1918,9 @@ flatted@^2.0.0:
   integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
 
 flow-parser@0.*:
-  version "0.87.0"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.87.0.tgz#a6d0e0b70f2cebdc15febb4eaf149877edbf145d"
-  integrity sha512-Yal9dssXDtme83dHDN2Mc+5FmnrTgnG1OS7imCaSjUdMFZJ8ZmvBhdxeSIHSr2GPsSK07PrR3nBdZLRieVeK3Q==
+  version "0.113.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.113.0.tgz#5b5913c54833918d0c3136ba69f6cf0cdd85fc20"
+  integrity sha512-+hRyEB1sVLNMTMniDdM1JIS8BJ3HUL7IFIJaxX+t/JUy0GNYdI0Tg1QLx8DJmOF8HeoCrUDcREpnDAc/pPta3w==
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Update flow-parser to 0.113 and increment the patch number to prepare for cutting a release.