### PR TITLE
Rename micromatch any to isMatch

### DIFF
--- a/src/ignoreFiles.js
+++ b/src/ignoreFiles.js
@@ -59,7 +59,7 @@ function addIgnoreFromFile(input) {
 }
 
 function shouldIgnore(path) {
-  const matched = matchers.length ? mm.any(path, matchers, { dot:true }) : false;
+  const matched = matchers.length ? mm.isMatch(path, matchers, { dot:true }) : false;
   return matched;
 }
 


### PR DESCRIPTION
I was checking `jscodeshift` and `micromatch` source code and saw that `.any` is there for backward compat, and they renamed it to `.isMatch` 

https://github.com/micromatch/micromatch/blob/fe4858b0c63b174fd3ae22674db39119b8fa4392/index.js#L126