### PR TITLE
add pattern into addIgnorePattern

### DIFF
--- a/src/ignoreFiles.js
+++ b/src/ignoreFiles.js
@@ -15,6 +15,7 @@ function addIgnorePattern(val) {
   if (val && typeof val === 'string' && val[0] !== '#') {
     let pattern = val;
     if (pattern.indexOf('/') === -1) {
+      matchers.push('**/' + pattern + '/**');
       matchers.push('**/' + pattern);
     } else if (pattern[pattern.length-1] === '/') {
       matchers.push('**/' + pattern + '**');


### PR DESCRIPTION
I believe this is closer to how `.gitignore` work but I'll let you guys decide if it should be merged or closed since it change the current behaviour.

For example, if we have the following in `.gitignore`:
```
node_modules
coverage
```

It ignores both directory.