### PR TITLE
allow testOptions in defineInlineTest

### DIFF
--- a/src/testUtils.js
+++ b/src/testUtils.js
@@ -117,11 +117,11 @@ function defineTest(dirName, transformName, options, testFilePrefix, testOptions
 }
 exports.defineTest = defineTest;
 
-function defineInlineTest(module, options, input, expectedOutput, testName) {
+function defineInlineTest(module, options, input, expectedOutput, testName, testOptions) {
   it(testName || 'transforms correctly', () => {
     runInlineTest(module, options, {
       source: input
-    }, expectedOutput);
+    }, expectedOutput, testOptions);
   });
 }
 exports.defineInlineTest = defineInlineTest;


### PR DESCRIPTION
## What?
Expose `testOptions` via `defineInlineTest` so that a parser option can be explicitly passed in

## Why?
Currently the following test case fails because the "parser" is not found by the `applyTransform` method when using es6 imports.

```js
import transform from './transform';

defineInlineTest(
    transformer,
    {},
    `
      import { FOO } from 'bar';
      const foo: FOO = 'foo';
    `,
    `
      import { FOO } from 'bar';
      const foo: FOO = 'foo';
    `,
    'it converts foo to bar',
  );
```

For example:

💥`import transform from './transform'`

vs 

✅ `const transform = require('transform');`


