### PR TITLE
Declare `@babel/preset-env` as an optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,11 @@
   "peerDependencies": {
     "@babel/preset-env": "^7.1.6"
   },
+  "peerDependenciesMeta": {
+    "@babel/preset-env": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",


### PR DESCRIPTION
See https://github.com/npm/cli/pull/224