### PR TITLE
feat: create template.asyncExpression

### DIFF
--- a/src/__tests__/template-test.js
+++ b/src/__tests__/template-test.js
@@ -108,7 +108,6 @@ while (i < 10) {
     )
     .toEqual(expected);
   });
-
   it('correctly parses expressions without any interpolation', () => {
     const expected = 'function() {}';
 
@@ -120,6 +119,15 @@ while (i < 10) {
     )
     .toEqual(expected);
   });
+
+  for (const parser of ['babel', 'babylon', 'flow', 'ts', 'tsx']) {
+    it(`asyncExpression correctly parses expressions with await -- ${parser}`, () => {
+      const expected = '{\n  bar: await baz\n}'
+      const j = jscodeshift.withParser(parser)
+
+      expect(j(j.template.asyncExpression`{\n  bar: await baz\n}`).toSource()).toEqual(expected)
+    })
+  }
 
   describe('explode arrays', () => {
 

--- a/src/template.js
+++ b/src/template.js
@@ -149,5 +149,25 @@ module.exports = function withParser(parser) {
     return expression;
   }
 
-  return {statements, statement, expression};
+  function asyncExpression(template/*, ...nodes*/) {
+    template = Array.from(template);
+    if (template.length > 0) {
+      template[0] = 'async () => (' + template[0];
+      template[template.length - 1] += ')';
+    }
+
+    const expression = statement.apply(
+      null,
+      [template].concat(Array.from(arguments).slice(1))
+    ).expression.body;
+
+    // Remove added parens
+    if (expression.extra) {
+      expression.extra.parenthesized = false;
+    }
+
+    return expression;
+  }
+
+  return {statements, statement, expression, asyncExpression};
 }


### PR DESCRIPTION
allows things like `` asyncExpression`foo ? await bar : baz` ``

I was tempted to make `expression` itself support this, but it has to wrap the code in `async () => (...)`, and theoretically some user-supplied parsers might not support async functions.