### PR TITLE
VariableDeclarator: add renameTo filters for Babel 6+ node types

### DIFF
--- a/src/collections/VariableDeclarator.js
+++ b/src/collections/VariableDeclarator.js
@@ -104,7 +104,34 @@ const transformMethods = {
           }
 
           if (
+            types.ObjectProperty.check(parent) &&
+            parent.key === path.node &&
+            !parent.computed
+          ) {
+            // { oldName: 3 }
+            return false;
+          }
+
+          if (
+            types.ObjectMethod.check(parent) &&
+            parent.key === path.node &&
+            !parent.computed
+          ) {
+            // { oldName() {} }
+            return false;
+          }
+
+          if (
             types.MethodDefinition.check(parent) &&
+            parent.key === path.node &&
+            !parent.computed
+          ) {
+            // class A { oldName() {} }
+            return false;
+          }
+
+          if (
+            types.ClassMethod.check(parent) &&
             parent.key === path.node &&
             !parent.computed
           ) {

--- a/src/collections/__tests__/VariableDeclarator-test.js
+++ b/src/collections/__tests__/VariableDeclarator-test.js
@@ -169,6 +169,62 @@ describe('VariableDeclarators', function() {
 
       expect(identifiers.length).toBe(1);
     });
+
+    describe('parsing with bablylon', function() {
+      it('does not rename object property', function () {
+        nodes = [
+          recast.parse('var foo = 42; var obj = { foo: null };', {
+            parser: getParser('babylon'),
+          }).program
+        ];
+        Collection
+          .fromNodes(nodes)
+          .findVariableDeclarators('foo').renameTo('newFoo');
+
+        expect(
+          Collection.fromNodes(nodes).find(types.Identifier, { name: 'newFoo' }).length
+        ).toBe(1);
+        expect(
+          Collection.fromNodes(nodes).find(types.Identifier, { name: 'foo' }).length
+        ).toBe(1);
+      })
+
+      it('does not rename object method', function () {
+        nodes = [
+          recast.parse('var foo = 42; var obj = { foo() {} };', {
+            parser: getParser('babylon'),
+          }).program
+        ];
+        Collection
+          .fromNodes(nodes)
+          .findVariableDeclarators('foo').renameTo('newFoo');
+
+        expect(
+          Collection.fromNodes(nodes).find(types.Identifier, { name: 'newFoo' }).length
+        ).toBe(1);
+        expect(
+          Collection.fromNodes(nodes).find(types.Identifier, { name: 'foo' }).length
+        ).toBe(1);
+      })
+
+      it('does not rename class method', function () {
+        nodes = [
+          recast.parse('var foo = 42; class A { foo() {} }', {
+            parser: getParser('babylon'),
+          }).program
+        ];
+        Collection
+          .fromNodes(nodes)
+          .findVariableDeclarators('foo').renameTo('newFoo');
+
+        expect(
+          Collection.fromNodes(nodes).find(types.Identifier, { name: 'newFoo' }).length
+        ).toBe(1);
+        expect(
+          Collection.fromNodes(nodes).find(types.Identifier, { name: 'foo' }).length
+        ).toBe(1);
+      })
+    });
   });
 
 });


### PR DESCRIPTION
We ran into this a while ago for  for `ClassProperty` (#296) but today we found a couple more places where `renameTo()` was incorrectly changing some identifiers. It looks like the current tests only run against the default Babel 5-compat parser and some types that were added in Babel 6 aren't considered. From the Babel 6.0 [changelog](https://github.com/babel/babel/blob/main/.github/CHANGELOG-v6.md#600):

>  * The `MethodDefinition` node type has been renamed to `ClassMethod` and it's `FunctionExpression` `value` property has been coerced into the main method node.
>  * The `Property` node type has been renamed to `ObjectProperty`.
>  * The `Property` node type with the boolean flag `method` has been renamed to `ObjectMethod` and its `FunctionExpression` `value` property has been coerced into the main method node.

The fix was just to add additional filters for `ObjectProperty`, `ObjectMethod`, and `ClassMethod`. Thanks!
