### PR TITLE
add childNodesOFType to JSX traversalMethods

### DIFF
--- a/src/collections/JSXElement.js
+++ b/src/collections/JSXElement.js
@@ -171,6 +171,25 @@ const traversalMethods = {
     });
     return Collection.fromPaths(paths, this, JSXElement);
   },
+
+  /**
+   * Returns all children that are of jsxElementType.
+   *
+   * @return {Collection<jsxElementType>}
+   */
+  childNodesOfType: function(jsxChildElementType) {
+    const paths = [];
+    this.forEach(function(path) {
+      const children = path.get('children');
+      const l = children.value.length;
+      for (let i = 0; i < l; i++) {
+        if (jsxChildElementType.check(children.value[i])) {
+          paths.push(children.get(i));
+        }
+      }
+    });
+    return Collection.fromPaths(paths, this, jsxChildElementType);
+  },
 };
 
 const mappingMethods = {

--- a/src/collections/__tests__/JSXElement-test.js
+++ b/src/collections/__tests__/JSXElement-test.js
@@ -37,6 +37,7 @@ describe('JSXCollection API', function() {
       '     <Baz.Bar />',
       '  </Child>',
       '  <Child id="2" foo="baz" baz/>',
+      '  {"foo"}',
       '</FooBar>'
     ].join('\n'), {parser: getParser()}).program];
   });
@@ -65,7 +66,7 @@ describe('JSXCollection API', function() {
         Collection.fromNodes(nodes)
         .findJSXElements('FooBar')
         .childNodes();
-      expect(children.length).toBe(5);
+      expect(children.length).toBe(7);
       expect(children.getTypes()).toContain('Expression');
     });
 
@@ -77,6 +78,16 @@ describe('JSXCollection API', function() {
 
       expect(children.length).toBe(2);
       expect(children.getTypes()).toContain('JSXElement');
+    });
+
+    it('returns the child element types of an JSXElement', function() {
+      const children =
+        Collection.fromNodes(nodes)
+        .findJSXElements('FooBar')
+        .childNodesOfType(types.JSXExpressionContainer);
+
+      expect(children.length).toBe(1);
+      expect(children.getTypes()).toContain('JSXExpressionContainer');
     });
 
     it('returns a properly typed collection even if empty', function() {


### PR DESCRIPTION
I wanted a function to get react children nodes that also works well with typing so that the collection returned will be of a specific JSXElement type (e.g. `JSXExpressionContainer`)

type defintion would look something like this:
```
childElements<T>(jsxChildElementType: types.Type<T>): Collection.Collection<T>;
```