### PR TITLE
feat: add testOptions to defineInlineTest, defineSnapshotTest

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ const defineSnapshotTest = require('jscodeshift/dist/testUtils').defineSnapshotT
 const transform = require('../myTransform');
 const transformOptions = {};
 /**
- * If you want to test snapshots of code written in TypeScript, Replace `const testOptions = { parser: 'ts' }`
+ * If you want to test snapshots of code written in TypeScript, Replace `const testOptions = { parser: 'ts' };`
 */
 const testOptions = {};
 defineSnapshotTest(transform, transformOptions, 'input', testOptions, 'test name (optional)');

--- a/README.md
+++ b/README.md
@@ -410,6 +410,13 @@ const transformOptions = {};
 defineInlineTest(transform, transformOptions, 'input', 'expected output', 'test name (optional)');
 ```
 
+If you want to test code written in TypeScript, add `testOptions`
+
+```js
+const testOptions = { parser: 'ts' };
+defineInlineTest(transform, transformOptions, 'input', 'expected output', testOptions, 'test name (optional)');
+```
+
 #### `defineSnapshotTest`
 
 Similar to `defineInlineTest` but instead of requiring an output value, it uses Jest's `toMatchSnapshot()` 

--- a/README.md
+++ b/README.md
@@ -425,7 +425,11 @@ Similar to `defineInlineTest` but instead of requiring an output value, it uses 
 const defineSnapshotTest = require('jscodeshift/dist/testUtils').defineSnapshotTest;
 const transform = require('../myTransform');
 const transformOptions = {};
-defineSnapshotTest(transform, transformOptions, 'input', 'test name (optional)');
+/**
+ * If you want to test snapshots of code written in TypeScript, Replace `const testOptions = { parser: 'ts' }`
+*/
+const testOptions = {};
+defineSnapshotTest(transform, transformOptions, 'input', testOptions, 'test name (optional)');
 ```
 
 For more information on snapshots, check out [Jest's docs](https://jestjs.io/docs/en/snapshot-testing)

--- a/sample/__tests__/__snapshots__/reverse-identifiers-test.js.snap
+++ b/sample/__tests__/__snapshots__/reverse-identifiers-test.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`reverse-identifiers Reverses function names 1`] = `"function noitcnuFa() {};"`;
+
+exports[`reverse-identifiers transforms correctly 1`] = `
+"var droWtsrif = 'Hello ';
+var droWdnoces = 'world';
+var egassem = droWtsrif + droWdnoces;"
+`;
+
+exports[`typescript/reverse-identifiers transforms correctly 1`] = `
+"const droWtsrif = 'Hello ';
+const droWdnoces = 'world';
+const egassem = droWtsrif + droWdnoces;
+const egasseMteg = (): string => egassem"
+`;

--- a/sample/__tests__/reverse-identifiers-test.js
+++ b/sample/__tests__/reverse-identifiers-test.js
@@ -18,6 +18,7 @@
 jest.autoMockOff();
 const defineTest = require('../../src/testUtils').defineTest;
 const defineInlineTest = require('../../src/testUtils').defineInlineTest;
+const defineSnapshotTest = require('../../src/testUtils').defineSnapshotTest;
 const transform = require('../reverse-identifiers');
 
 defineTest(__dirname, 'reverse-identifiers');
@@ -38,6 +39,17 @@ var egassem = droWtsrif + droWdnoces;
     'function noitcnuFa() {};',
     'Reverses function names'
   );
+
+  defineSnapshotTest(transform, {}, `
+var firstWord = 'Hello ';
+var secondWord = 'world';
+var message = firstWord + secondWord;`
+  );
+  defineSnapshotTest(transform, {},
+    'function aFunction() {};',
+    {},
+    'Reverses function names'
+  );
 });
 
 describe('typescript/reverse-identifiers', () => {
@@ -53,4 +65,11 @@ const egassem = droWtsrif + droWdnoces;
 
 const egasseMteg = (): string => egassem
   `, { parser: 'ts' });
+
+  defineSnapshotTest(transform, {}, `
+const firstWord = 'Hello ';
+const secondWord = 'world';
+const message = firstWord + secondWord;
+const getMessage = (): string => message
+  `, { parser: 'ts' })
 });

--- a/sample/__tests__/reverse-identifiers-test.js
+++ b/sample/__tests__/reverse-identifiers-test.js
@@ -39,3 +39,18 @@ var egassem = droWtsrif + droWdnoces;
     'Reverses function names'
   );
 });
+
+describe('typescript/reverse-identifiers', () => {
+  defineInlineTest(transform, {}, `
+const firstWord = 'Hello ';
+const secondWord = 'world';
+const message = firstWord + secondWord;
+
+const getMessage = (): string => message`,`
+const droWtsrif = 'Hello ';
+const droWdnoces = 'world';
+const egassem = droWtsrif + droWdnoces;
+
+const egasseMteg = (): string => egassem
+  `, { parser: 'ts' });
+});

--- a/sample/__tests__/reverse-identifiers-test.js
+++ b/sample/__tests__/reverse-identifiers-test.js
@@ -72,5 +72,5 @@ const firstWord = 'Hello ';
 const secondWord = 'world';
 const message = firstWord + secondWord;
 const getMessage = (): string => message
-  `, { parser: 'ts' })
+  `, { parser: 'ts' });
 });

--- a/sample/__tests__/reverse-identifiers-test.js
+++ b/sample/__tests__/reverse-identifiers-test.js
@@ -37,6 +37,7 @@ var egassem = droWtsrif + droWdnoces;
   defineInlineTest(transform, {},
     'function aFunction() {};',
     'function noitcnuFa() {};',
+    {},
     'Reverses function names'
   );
 

--- a/src/testUtils.js
+++ b/src/testUtils.js
@@ -36,8 +36,8 @@ function applyTransform(module, options, input, testOptions = {}) {
 }
 exports.applyTransform = applyTransform;
 
-function runSnapshotTest(module, options, input) {
-  const output = applyTransform(module, options, input);
+function runSnapshotTest(module, options, input, testOptions) {
+  const output = applyTransform(module, options, input, testOptions);
   expect(output).toMatchSnapshot();
   return output;
 }
@@ -126,11 +126,11 @@ function defineInlineTest(module, options, input, expectedOutput, testOptions, t
 }
 exports.defineInlineTest = defineInlineTest;
 
-function defineSnapshotTest(module, options, input, testName) {
+function defineSnapshotTest(module, options, input, testOptions, testName) {
   it(testName || 'transforms correctly', () => {
     runSnapshotTest(module, options, {
       source: input
-    });
+    }, testOptions);
   });
 }
 exports.defineSnapshotTest = defineSnapshotTest;

--- a/src/testUtils.js
+++ b/src/testUtils.js
@@ -117,11 +117,11 @@ function defineTest(dirName, transformName, options, testFilePrefix, testOptions
 }
 exports.defineTest = defineTest;
 
-function defineInlineTest(module, options, input, expectedOutput, testName) {
+function defineInlineTest(module, options, input, expectedOutput, testOptions, testName) {
   it(testName || 'transforms correctly', () => {
     runInlineTest(module, options, {
       source: input
-    }, expectedOutput);
+    }, expectedOutput, testOptions);
   });
 }
 exports.defineInlineTest = defineInlineTest;


### PR DESCRIPTION
This is because I considered `defineInlineTest` ( and `defineSnapshotTest` ) should be able to accept `testOptions`, I added the code shown below.

```js
// src/testUnit.js > defineInlineTest

- function defineInlineTest(module, options, input, expectedOutput, testName) {
-   it(testName || 'transforms correctly', () => {
-     runInlineTest(module, options, {
-       source: input
-     }, expectedOutput);
-   });
- }

+ function defineInlineTest(module, options, input, expectedOutput, testOptions, testName) {
+   it(testName || 'transforms correctly', () => {
+     runInlineTest(module, options, {
+       source: input
+     }, expectedOutput, testOptions);
+   });
+ }
```

It allows inline testing and snapshot testing of code written in TypeScript.