### PR TITLE
Remove lodash dependency from tsx parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "colors": "^1.1.2",
     "flow-parser": "0.*",
     "graceful-fs": "^4.2.4",
+    "lodash": "^4.17.19",
     "micromatch": "^3.1.10",
     "neo-async": "^2.5.0",
     "node-dir": "^0.1.17",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "colors": "^1.1.2",
     "flow-parser": "0.*",
     "graceful-fs": "^4.2.4",
-    "lodash": "^4.17.19",
     "micromatch": "^3.1.10",
     "neo-async": "^2.5.0",
     "node-dir": "^0.1.17",

--- a/parser/tsx.js
+++ b/parser/tsx.js
@@ -8,11 +8,9 @@
 
 'use strict';
 
-const _ = require('lodash');
 const babylon = require('@babel/parser');
-const baseOptions = require('./tsOptions');
-
-const options = _.merge(baseOptions, { plugins: ['jsx'] });
+const options = require('./tsOptions');
+options.plugins.push('jsx');
 
 /**
  * Doesn't accept custom options because babylon should be used directly in


### PR DESCRIPTION
Lodash is required by the `tsx` parser, but it was not listed in `dependencies`, so `npx jscodeshift --parser=tsx thing.tsx` would always fail. 

Resolves #426
Resolves #418 

I added the dependency as `^4.17.19` because that was one that was already included in yarn.lock (thanks to existing dev dependencies), so as to avoid making any bigger diff than necessary.

**Update:** see comments below. I removed the lodash dependency entirely instead.