### PR TITLE
Add missing lodash dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "colors": "^1.1.2",
     "flow-parser": "0.*",
     "graceful-fs": "^4.2.4",
+    "lodash": "^4.17.21",
     "micromatch": "^3.1.10",
     "neo-async": "^2.5.0",
     "node-dir": "^0.1.17",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2855,7 +2855,7 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.19, lodash@^4.17.4:
+lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.17.4:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
Lodash is required by parser/tsx.js but is not explicitly depended on.
Usually it seems to work okay due to the fact that other dependencies of jscodeshift
pull in lodash, but for some reason it started failing recently for us when running
jscodeshift through npx, so figured it's time to correct the missing dep

See: https://github.com/facebook/jscodeshift/blob/master/parser/tsx.js#L11