### PR TITLE
Add lodash as explicit dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "colors": "^1.1.2",
     "flow-parser": "0.*",
     "graceful-fs": "^4.2.4",
+    "lodash": "^4.17.21",
     "micromatch": "^3.1.10",
     "neo-async": "^2.5.0",
     "node-dir": "^0.1.17",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2855,7 +2855,7 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.19, lodash@^4.17.4:
+lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.17.4:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
JSCodeShift [uses lodash](https://github.com/facebook/jscodeshift/blob/57a9d9c731429da624655472290a7b4802e7e8d7/parser/tsx.js#L11) when using the tsx parser. 

However, lodash is not specified explicitly in package.json. It seems that it is available via implicit [phantom dependency](https://rushjs.io/pages/advanced/phantom_deps/).

This makes JSCodeShift to break when using strict package managers such as Yarn 2+ or pnpm.

This PR includes lodash as an explicit dependency to fix the problem.