### PR TITLE
Remove lodash dependency from tsx parser 

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "roots": [
       "src",
       "bin",
+      "parser",
       "sample"
     ]
   }

--- a/parser/__tests__/.eslintrc
+++ b/parser/__tests__/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "globals": {
+    "jest": true
+  },
+  "env": {
+    "jasmine": true
+  }
+}

--- a/parser/__tests__/__snapshots__/tsx-test.js.snap
+++ b/parser/__tests__/__snapshots__/tsx-test.js.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`tsxParser parse extends the ts config with jsx support 1`] = `
+Array [
+  "\\"mock content\\";",
+  Object {
+    "allowImportExportEverywhere": true,
+    "allowReturnOutsideFunction": true,
+    "plugins": Array [
+      "jsx",
+      "asyncGenerators",
+      "bigInt",
+      "classPrivateMethods",
+      "classPrivateProperties",
+      "classProperties",
+      "decorators-legacy",
+      "doExpressions",
+      "dynamicImport",
+      "exportDefaultFrom",
+      "exportExtensions",
+      "exportNamespaceFrom",
+      "functionBind",
+      "functionSent",
+      "importMeta",
+      "nullishCoalescingOperator",
+      "numericSeparator",
+      "objectRestSpread",
+      "optionalCatchBinding",
+      "optionalChaining",
+      Array [
+        "pipelineOperator",
+        Object {
+          "proposal": "minimal",
+        },
+      ],
+      "throwExpressions",
+      "typescript",
+    ],
+    "sourceType": "module",
+    "startLine": 1,
+    "tokens": true,
+  },
+]
+`;

--- a/parser/__tests__/tsx-test.js
+++ b/parser/__tests__/tsx-test.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/*global jest, describe, it, expect*/
+
+'use strict';
+
+jest.mock('@babel/parser')
+const babylon = require('@babel/parser');
+
+const tsxParser = require('../tsx');
+
+describe('tsxParser', function() {
+  describe('parse', function() {
+    it('extends the ts config with jsx support', function() {
+      const parser = tsxParser();
+      parser.parse('"mock content";');
+
+      expect(babylon.parse).toHaveBeenCalledTimes(1);
+      expect(babylon.parse.mock.calls[0]).toMatchSnapshot();
+    });
+  });
+});

--- a/parser/tsx.js
+++ b/parser/tsx.js
@@ -8,11 +8,11 @@
 
 'use strict';
 
-const _ = require('lodash');
 const babylon = require('@babel/parser');
 const baseOptions = require('./tsOptions');
 
-const options = _.merge(baseOptions, { plugins: ['jsx'] });
+const options = Object.assign({}, baseOptions);
+options.plugins = ['jsx'].concat(baseOptions.plugins);
 
 /**
  * Doesn't accept custom options because babylon should be used directly in


### PR DESCRIPTION
Resolves #418
Replaces https://github.com/facebook/jscodeshift/pull/427

Opening a new PR with some added tests and the suggested fixes since the last PR has set for a few weeks now. Feel free to close this in favor of the PR added by @robyoder, but this bug is painful enough for my use case that I'd love to see it get fixed and released, so figured I'd quickly do some of the legwork for testing it out 😄.

The PR:
* Removes the undeclared dependency on lodash
* Stops overriding the value of `asyncGenerators` in the plugins array with `jsx`
* Stops mutating the return value of `tsOptions`