### PR TITLE
Make dependency on temp version slightly stricter

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "neo-async": "^2.5.0",
     "node-dir": "^0.1.17",
     "recast": "^0.20.4",
-    "temp": "^0.8.1",
+    "temp": "^0.8.4",
     "write-file-atomic": "^2.3.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3747,7 +3747,7 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-rimraf@2.6.3:
+rimraf@2.6.3, rimraf@~2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
@@ -3760,11 +3760,6 @@ rimraf@^2.6.1:
   integrity sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==
   dependencies:
     glob "^7.0.5"
-
-rimraf@~2.2.6:
-  version "2.2.8"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
-  integrity sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=
 
 rsvp@^3.3.3:
   version "3.6.2"
@@ -4174,13 +4169,12 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
 
-temp@^0.8.1:
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/temp/-/temp-0.8.3.tgz#e0c6bc4d26b903124410e4fed81103014dfc1f59"
-  integrity sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=
+temp@^0.8.4:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/temp/-/temp-0.8.4.tgz#8c97a33a4770072e0a05f919396c7665a7dd59f2"
+  integrity sha512-s0ZZzd0BzYv5tLSptZooSjK8oj6C+c19p7Vqta9+6NPOf7r+fxq0cJe6/oN4LTC79sy5NY8ucOJNgwsKCSbfqg==
   dependencies:
-    os-tmpdir "^1.0.0"
-    rimraf "~2.2.6"
+    rimraf "~2.6.2"
 
 test-exclude@^4.2.1:
   version "4.2.3"


### PR DESCRIPTION
With `temp@0.8.3` installed and the `babel` option enabled, Babel throws due to the legacy octal literals used within `temp/lib/temp.js`:

```
SyntaxError: /.../node_modules/temp/lib/temp.js: Legacy octal literals are not allowed in strict mode. (226:20)

  224 | function mkdir(affixes, callback) {
  225 |   var dirPath = generateName(affixes, 'd-');
> 226 |   fs.mkdir(dirPath, 0700, function(err) {
      |                     ^
  227 |     if (!err) {
  228 |       deleteDirOnExit(dirPath);
  229 |     }
```

It looks like this issue was fixed in `0.8.4`, which uses `parseInt` instead. Most packages would automatically be using this newer version regardless, but I ran across a few at my org where after upgrading `jscodeshift` I'd hit this issue since `temp` was locked to an older version. Making the dep a bit more explicit here should save needing to manually upgrade the transitive dependency in these cases.