### PR TITLE
fix: Set `configFile: false` option in `@babel/register`

### DIFF
--- a/src/Worker.js
+++ b/src/Worker.js
@@ -67,6 +67,7 @@ function setup(tr, babel) {
     );
 
     require('@babel/register')({
+      configFile: false,
       babelrc: false,
       presets,
       plugins: [


### PR DESCRIPTION
JSCodeShift is transpiling transform files given as arguments, and it is currently ignoring package-wide `.babelrc` settings file in `@babel/register` so that it shows a consistent behavior across many packages. 

However, since `configFile` option is not set to false, it is still affected by the project-wide `babel.config.js` settings file. Hence in some cases JSCodeShift may behave differently, depending on the settings of `babel.config.js`.

This PR fixes this behavior by setting `configFile: false` option to `@babel/register`, so that JSCodeShift behaves completely independent of the project-wide settings of babel.