### PR TITLE
feat: add a snapshot test util that loads the file for users

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,17 @@ defineSnapshotTest(transform, transformOptions, 'input', 'test name (optional)')
 
 For more information on snapshots, check out [Jest's docs](https://jestjs.io/docs/en/snapshot-testing)
 
+#### `defineSnapshotTestFromFixture`
+
+Similar to `defineSnapshotTest` but will load the file using same file-directory defaults as `defineTest`
+
+```js
+const defineSnapshotTestDefault = require('jscodeshift/dist/testUtils').defineSnapshotTestDefault;
+const transform = require('../myTransform');
+const transformOptions = {};
+defineSnapshotTestFromFixture(__dirname, transform, transformOptions, 'FirstFixture', 'test name (optional)');
+```
+
 #### `applyTransform`
 
 Executes your transform using the options and the input given and returns the result.

--- a/sample/__tests__/__snapshots__/reverse-identifiers-test.js.snap
+++ b/sample/__tests__/__snapshots__/reverse-identifiers-test.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`transforms correctly 1`] = `
+"var droWtsrif = 'Hello ';
+var droWdnoces = 'world';
+var egassem = droWtsrif + droWdnoces;
+
+class ooF {
+  @detaroced
+  *rab() { }
+}"
+`;

--- a/sample/__tests__/reverse-identifiers-test.js
+++ b/sample/__tests__/reverse-identifiers-test.js
@@ -18,6 +18,7 @@
 jest.autoMockOff();
 const defineTest = require('../../src/testUtils').defineTest;
 const defineInlineTest = require('../../src/testUtils').defineInlineTest;
+const defineSnapshotTestFromFixture = require('../../src/testUtils').defineSnapshotTestFromFixture;
 const transform = require('../reverse-identifiers');
 
 defineTest(__dirname, 'reverse-identifiers');
@@ -39,3 +40,6 @@ var egassem = droWtsrif + droWdnoces;
     'Reverses function names'
   );
 });
+
+// the snapshot output of this file should be the same as reverse-identifiers.output.js
+defineSnapshotTestFromFixture(__dirname, transform, {}, 'reverse-identifiers');

--- a/src/testUtils.js
+++ b/src/testUtils.js
@@ -134,3 +134,15 @@ function defineSnapshotTest(module, options, input, testName) {
   });
 }
 exports.defineSnapshotTest = defineSnapshotTest;
+
+/**
+ * Handles file-loading boilerplates, using same defaults as defineTest
+ */
+function defineSnapshotTestFromFixture(dirName, module, options, testFilePrefix, testName, testOptions = {}) {
+  const extension = extensionForParser(testOptions.parser)
+  const fixtureDir = path.join(dirName, '..', '__testfixtures__');
+  const inputPath = path.join(fixtureDir, testFilePrefix + `.input.${extension}`);
+  const source = fs.readFileSync(inputPath, 'utf8');
+  defineSnapshotTest(module, options, source, testName)
+}
+exports.defineSnapshotTestFromFixture = defineSnapshotTestFromFixture;


### PR DESCRIPTION
Adds a wrapper function, `defineSnapshotWithFixture` around `defineSnapshotTest` that mimics the loading/parsing behavior of `defineTest` to load the file based on the testFilePrefix in the `__testfixtures__` directory. Adds a quick test in the sample directory as well as updates documentation.