### PR TITLE
fix: make `@babel/preset-env` optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,11 @@
   "peerDependencies": {
     "@babel/preset-env": "^7.1.6"
   },
+  "peerDependenciesMeta": {
+    "@babel/preset-env": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",


### PR DESCRIPTION
I think this achieves what #375 wanted (use it if provided, but doesn't warn if missing)