### PR TITLE
Tabs to spaces in code examples for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,18 +320,18 @@ node types and are not callable on differently typed collections.
 ```js
 // Adding a method to all Identifiers
 jscodeshift.registerMethods({
-	logNames: function() {
-		return this.forEach(function(path) {
-			console.log(path.node.name);
-		});
-	}
+  logNames: function() {
+    return this.forEach(function(path) {
+      console.log(path.node.name);
+    });
+  }
 }, jscodeshift.Identifier);
 
 // Adding a method to all collections
 jscodeshift.registerMethods({
-	findIdentifiers: function() {
-		return this.find(jscodeshift.Identifier);
-	}
+  findIdentifiers: function() {
+    return this.find(jscodeshift.Identifier);
+  }
 });
 
 jscodeshift(ast).findIdentifiers().logNames();


### PR DESCRIPTION
One of the code blocks was using tabs instead of spaces, which was inconsistent with the rest of the README.