### PR TITLE
Add renameTo filters for Babel 6+ node types

### DIFF
--- a/src/collections/VariableDeclarator.js
+++ b/src/collections/VariableDeclarator.js
@@ -104,7 +104,34 @@ const transformMethods = {
           }
 
           if (
+            types.ObjectProperty.check(parent) &&
+            parent.key === path.node &&
+            !parent.computed
+          ) {
+            // { oldName: 3 }
+            return false;
+          }
+
+          if (
+            types.ObjectMethod.check(parent) &&
+            parent.key === path.node &&
+            !parent.computed
+          ) {
+            // { oldName() {} }
+            return false;
+          }
+
+          if (
             types.MethodDefinition.check(parent) &&
+            parent.key === path.node &&
+            !parent.computed
+          ) {
+            // class A { oldName() {} }
+            return false;
+          }
+
+          if (
+            types.ClassMethod.check(parent) &&
             parent.key === path.node &&
             !parent.computed
           ) {

--- a/src/collections/__tests__/VariableDeclarator-test.js
+++ b/src/collections/__tests__/VariableDeclarator-test.js
@@ -170,6 +170,62 @@ describe('VariableDeclarators', function() {
 
       expect(identifiers.length).toBe(1);
     });
+
+    describe('parsing with bablylon', function() {
+      it('does not rename object property', function () {
+        nodes = [
+          recast.parse('var foo = 42; var obj = { foo: null };', {
+            parser: getParser('babylon'),
+          }).program
+        ];
+        Collection
+          .fromNodes(nodes)
+          .findVariableDeclarators('foo').renameTo('newFoo');
+
+        expect(
+          Collection.fromNodes(nodes).find(types.Identifier, { name: 'newFoo' }).length
+        ).toBe(1);
+        expect(
+          Collection.fromNodes(nodes).find(types.Identifier, { name: 'foo' }).length
+        ).toBe(1);
+      })
+
+      it('does not rename object method', function () {
+        nodes = [
+          recast.parse('var foo = 42; var obj = { foo() {} };', {
+            parser: getParser('babylon'),
+          }).program
+        ];
+        Collection
+          .fromNodes(nodes)
+          .findVariableDeclarators('foo').renameTo('newFoo');
+
+        expect(
+          Collection.fromNodes(nodes).find(types.Identifier, { name: 'newFoo' }).length
+        ).toBe(1);
+        expect(
+          Collection.fromNodes(nodes).find(types.Identifier, { name: 'foo' }).length
+        ).toBe(1);
+      })
+
+      it('does not rename class method', function () {
+        nodes = [
+          recast.parse('var foo = 42; class A { foo() {} }', {
+            parser: getParser('babylon'),
+          }).program
+        ];
+        Collection
+          .fromNodes(nodes)
+          .findVariableDeclarators('foo').renameTo('newFoo');
+
+        expect(
+          Collection.fromNodes(nodes).find(types.Identifier, { name: 'newFoo' }).length
+        ).toBe(1);
+        expect(
+          Collection.fromNodes(nodes).find(types.Identifier, { name: 'foo' }).length
+        ).toBe(1);
+      })
+    });
   });
 
 });


### PR DESCRIPTION
Was not able to get in touch with @henryqdineen, so putting in this PR to origin.