### PR TITLE
Removing dependency on args being in alphabetical order.

### DIFF
--- a/bin/jscodeshift.js
+++ b/bin/jscodeshift.js
@@ -17,6 +17,7 @@ const pkg = require('../package.json');
 const parser = require('../src/argsParser')
   .options({
     transform: {
+      display_index: 15,
       abbr: 't',
       default: './transform.js',
       help: 'path to the transform file. Can be either a local path or url',
@@ -24,6 +25,7 @@ const parser = require('../src/argsParser')
       required: true
     },
     cpus: {
+      display_index: 1,
       abbr: 'c',
       help: 'start at most N child processes to process source files',
       defaultHelp: 'max(all - 1, 1)',
@@ -31,6 +33,7 @@ const parser = require('../src/argsParser')
       process: Number,
     },
     verbose: {
+      display_index: 16,
       abbr: 'v',
       choices: [0, 1, 2],
       default: 0,
@@ -39,69 +42,87 @@ const parser = require('../src/argsParser')
       process: Number,
     },
     dry: {
+      display_index: 2,
       abbr: 'd',
       flag: true,
       default: false,
       help: 'dry run (no changes are made to files)'
     },
     print: {
+      display_index: 11,
       abbr: 'p',
       flag: true,
       default: false,
       help: 'print transformed files to stdout, useful for development'
     },
     babel: {
+      display_index: 0,
       flag: true,
       default: true,
       help: 'apply babeljs to the transform file'
     },
     extensions: {
+      display_index: 3,
       default: 'js',
       help: 'transform files with these file extensions (comma separated list)',
       metavar: 'EXT',
     },
     ignorePattern: {
+      display_index: 7,
       full: 'ignore-pattern',
       list: true,
       help: 'ignore files that match a provided glob expression',
       metavar: 'GLOB',
     },
     ignoreConfig: {
+      display_index: 6,
       full: 'ignore-config',
       list: true,
       help: 'ignore files if they match patterns sourced from a configuration file (e.g. a .gitignore)',
       metavar: 'FILE'
     },
+    gitignore: {
+      display_index: 8,
+      flag: true,
+      default: false,
+      help: 'adds entries the current directory\'s .gitignore file',
+    },
     runInBand: {
+      display_index: 12,
       flag: true,
       default: false,
       full: 'run-in-band',
       help: 'run serially in the current process'
     },
     silent: {
+      display_index: 13,
       abbr: 's',
       flag: true,
       default: false,
       help: 'do not write to stdout or stderr'
     },
     parser: {
+      display_index: 9,
       choices: ['babel', 'babylon', 'flow', 'ts', 'tsx'],
       default: 'babel',
       help: 'the parser to use for parsing the source files'
     },
     parserConfig: {
+      display_index: 10,
       full: 'parser-config',
       help: 'path to a JSON file containing a custom parser configuration for flow or babylon',
       metavar: 'FILE',
       process: file => JSON.parse(fs.readFileSync(file)),
     },
     failOnError: {
+      display_index: 4,
       flag: true,
       help: 'Return a non-zero code when there are errors',
       full: 'fail-on-error',
       default: false,
     },
     version: {
+      display_index: 17,
       help: 'print version and exit',
       callback: function() {
         const requirePackage = require('../utils/requirePackage');
@@ -115,6 +136,7 @@ const parser = require('../src/argsParser')
       },
     },
     stdin: {
+      display_index: 14,
       help: 'read file/directory list from stdin',
       flag: true,
       default: false,

--- a/src/argsParser.js
+++ b/src/argsParser.js
@@ -48,7 +48,17 @@ function formatOption(option) {
 function getHelpText(options) {
   const opts = Object.keys(options)
     .map(k => options[k])
-    .sort((a,b) => a.full.localeCompare(b.full));
+    .sort((a,b) => {
+      if (a.display_index > b.display_index) {
+        return 1;
+      } else if (a.display_index < b.display_index) {
+        return -1;
+      } else if (a.display_index === b.display_index) {
+        return 0;
+      } else {
+        return -1;
+      }
+    });
 
   const text = `
 Usage: jscodeshift [OPTION]... PATH...
@@ -89,6 +99,7 @@ function validateOptions(parsedOptions, options) {
 
 function prepareOptions(options) {
   options.help = {
+    display_index: 5,
     abbr: 'h',
     help: 'print this help and exit',
     callback() {

--- a/src/argsParser.js
+++ b/src/argsParser.js
@@ -48,17 +48,7 @@ function formatOption(option) {
 function getHelpText(options) {
   const opts = Object.keys(options)
     .map(k => options[k])
-    .sort((a,b) => {
-      if (a.display_index > b.display_index) {
-        return 1;
-      } else if (a.display_index < b.display_index) {
-        return -1;
-      } else if (a.display_index === b.display_index) {
-        return 0;
-      } else {
-        return -1;
-      }
-    });
+    .sort((a,b) => a.display_index - b.display_index);
 
   const text = `
 Usage: jscodeshift [OPTION]... PATH...


### PR DESCRIPTION
Previously, the arg parser would display the arguments in the help section in alphabetical order. If you run ```jscodeshift -h``` you've notice all the arguments are displayed in alphabetical order. The algorithm that prints out the help page actually relies on them being in alphabetical order. The problem with this approach is that if there's a command that should be included in a category of arguments that appears in the middle of the page, but the new argument starts with a "z", then the new argument will appear in the last lines on the help page, and not in the middle where it's supposed to be.


Since we're need to move in the direction of grouping arguments by functionality independent of names (like for upcoming --gitignore flag), we now have to come up with a quick refactoring that allows arguments to be displayed in a specified order regardless of what alphabetical order the arguments themselves occupy.