### PR TITLE
Adding --gitignore flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ All options are also passed to the transformer, which means you can supply custo
   -h, --help                    print this help and exit
       --ignore-config=FILE ...  ignore files if they match patterns sourced from a configuration file (e.g. a .gitignore)
       --ignore-pattern=GLOB ...  ignore files that match a provided glob expression
+      --(no-)gitignore          adds entries the current directory's .gitignore file
+                                (default: false)
       --parser=babel|babylon|flow|ts|tsx  the parser to use for parsing the source files
                                           (default: babel)
       --parser-config=FILE      path to a JSON file containing a custom parser configuration for flow or babylon
@@ -215,14 +217,14 @@ __Example: specifying parser type string in the transform file__
 module.exports = function transformer(file, api, options) {
   const j = api.jscodeshift;
   const rootSource = j(file.source);
-  
+
   // whatever other code...
-  
+
   return rootSource.toSource();
 }
-  
+
 // use the flow parser
-module.exports.parser = 'flow'; 
+module.exports.parser = 'flow';
 ```
 
 __Example: specifying a custom parser object in the transform file__
@@ -232,9 +234,9 @@ __Example: specifying a custom parser object in the transform file__
 module.exports = function transformer(file, api, options) {
   const j = api.jscodeshift;
   const rootSource = j(file.source);
-  
+
   // whatever other code...
-  
+
   return rootSource.toSource();
 }
 
@@ -392,6 +394,40 @@ jscodeshift.registerMethods({
 
 jscodeshift(ast).findIdentifiers().logNames();
 jscodeshift(ast).logNames(); // error, unless `ast` only consists of Identifier nodes
+```
+
+### Ignoring files and directories
+
+
+Sometimes there are files and directories that you want to avoid running transforms on. For example, the node_modules/ directory, where the project's installed local npm packages reside, can introduce bugs if any files in it are accidentally transformed by jscodeshift.
+
+The simplest way to avoid many of these unwanted transforms is to pass jscodeshift the __—gitignore__ flag, which uses the glob patterns specified in your project’s .gitignore file to avoid transforming anything in directories such as node_modules/, dist/, etc. In most cases anything you want git to ignore you proabably are also going to want jscodeshift to ignore as well. _Please note that the .gitignore file use will be taken from the current working directory from which jscodeshift is being run._
+
+```
+jscodeshift --gitignore mytransform.js
+```
+
+For more custom ignore functionality, the __--ignore-pattern__ and the __--ignore-config__ arguments can be used.
+
+
+__--ignore-pattern__  takes a [.gitignore format](https://git-scm.com/docs/gitignore#_pattern_format) glob pattern that specifies file and directory patterns to ignore
+
+```
+jscodeshift -—ignore-pattern="js_configuration_files/**/*” mytransform.js
+
+// More than one ignore
+jscodeshift -—ignore-pattern="first_ignored_dir/**/*” -—ignore-pattern="second_ignored_dir/**/*” mytransform.js
+```
+
+__--ignore-config__ takes one or more paths to files containing lines with [.gitignore format](https://git-scm.com/docs/gitignore#_pattern_format) glob patterns.
+```
+
+// note: .gitignore is a random made-up filename extension for this example
+
+jscodeshift -—ignore-config="MyIgnoreFile.gitignore" mytransform.js
+
+// More than one ignore file
+jscodeshift -—ignore-pattern="first_ignore_file.gitignore” -—ignore-pattern="second_ignore_file.gitignore” mytransform.js
 ```
 
 ### Passing options to [recast]

--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ jscodeshift(ast).logNames(); // error, unless `ast` only consists of Identifier 
 
 Sometimes there are files and directories that you want to avoid running transforms on. For example, the node_modules/ directory, where the project's installed local npm packages reside, can introduce bugs if any files in it are accidentally transformed by jscodeshift.
 
-The simplest way to avoid many of these unwanted transforms is to pass jscodeshift the __—gitignore__ flag, which uses the glob patterns specified in your project’s .gitignore file to avoid transforming anything in directories such as node_modules/, dist/, etc. In most cases anything you want git to ignore you proabably are also going to want jscodeshift to ignore as well. _Please note that the .gitignore file use will be taken from the current working directory from which jscodeshift is being run._
+The simplest way to avoid many of these unwanted transforms is to pass jscodeshift the __--gitignore__ flag, which uses the glob patterns specified in your project’s .gitignore file to avoid transforming anything in directories such as node_modules/, dist/, etc. In most cases anything you want git to ignore you proabably are also going to want jscodeshift to ignore as well. _Please note that the .gitignore file use will be taken from the current working directory from which jscodeshift is being run._
 
 ```
 jscodeshift --gitignore mytransform.js
@@ -413,10 +413,10 @@ For more custom ignore functionality, the __--ignore-pattern__ and the __--ignor
 __--ignore-pattern__  takes a [.gitignore format](https://git-scm.com/docs/gitignore#_pattern_format) glob pattern that specifies file and directory patterns to ignore
 
 ```
-jscodeshift -—ignore-pattern="js_configuration_files/**/*” mytransform.js
+jscodeshift --ignore-pattern="js_configuration_files/**/*” mytransform.js
 
 // More than one ignore
-jscodeshift -—ignore-pattern="first_ignored_dir/**/*” -—ignore-pattern="second_ignored_dir/**/*” mytransform.js
+jscodeshift --ignore-pattern="first_ignored_dir/**/*” -—ignore-pattern="second_ignored_dir/**/*” mytransform.js
 ```
 
 __--ignore-config__ takes one or more paths to files containing lines with [.gitignore format](https://git-scm.com/docs/gitignore#_pattern_format) glob patterns.
@@ -424,10 +424,10 @@ __--ignore-config__ takes one or more paths to files containing lines with [.git
 
 // note: .gitignore is a random made-up filename extension for this example
 
-jscodeshift -—ignore-config="MyIgnoreFile.gitignore" mytransform.js
+jscodeshift --ignore-config="MyIgnoreFile.gitignore" mytransform.js
 
 // More than one ignore file
-jscodeshift -—ignore-pattern="first_ignore_file.gitignore” -—ignore-pattern="second_ignore_file.gitignore” mytransform.js
+jscodeshift --ignore-pattern="first_ignore_file.gitignore” --ignore-pattern="second_ignore_file.gitignore” mytransform.js
 ```
 
 ### Passing options to [recast]

--- a/bin/__tests__/jscodeshift-test.js
+++ b/bin/__tests__/jscodeshift-test.js
@@ -20,7 +20,7 @@ const path = require('path');
 const temp = require('temp');
 const mkdirp = require('mkdirp');
 const testUtils = require('../../utils/testUtils');
-const { chdir } = require('process');
+const {chdir} = require('process');
 
 const createTransformWith = testUtils.createTransformWith;
 const createTempFileWith = testUtils.createTempFileWith;

--- a/src/Runner.js
+++ b/src/Runner.js
@@ -168,9 +168,16 @@ function run(transformFile, paths, options) {
   const statsCounter = {};
   const startTime = process.hrtime();
 
+  ignores.add(options.ignoreSet);
   ignores.add(options.ignorePattern);
   ignores.addFromFile(options.ignoreConfig);
 
+  if (options.gitignore) {
+    let currDirectory = process.cwd();
+    let gitIgnorePath = path.join(currDirectory, '.gitignore');
+    ignores.addFromFile(gitIgnorePath);
+  }
+ 
   if (/^http/.test(transformFile)) {
     usedRemoteScript = true;
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
Adds a --gitignore flag that uses a .gitignore file in the current working directory to force jscodeshift to abstain from transforming files that match patterns specified in the .gitignore file.

Please note that this feature is added primarily for the benefit of beginners to jscodeshift, as a way to make the enormously timesaving technique of passing a project's .gitignore file to jscodeshift easily discoverable and learnable. The idea is that when the user looks at the jscodeshift help page, "--gitignore" jumps right out at them and they immediately make the connection.

It took me a year and a half of using jscodeshift before I realized I could simply just pass .gitignore to the utiliity, and creating a new ignore file for a freshly cloned project every day is an annoyance I wouldn't wish on others.

Due to the --gitignore flag being a discoverability feature, renaming it to something generic would impede the discoverability it's trying to promote.