### PR TITLE
Allow the j shortcut in testUtils

### DIFF
--- a/src/testUtils.js
+++ b/src/testUtils.js
@@ -27,6 +27,7 @@ function applyTransform(module, options, input, testOptions = {}) {
     input,
     {
       jscodeshift,
+      j: jscodeshift,
       stats: () => {},
     },
     options || {}


### PR DESCRIPTION
Since the API allows the `j` shortcut, the mock test API should implement it as well.