### PR TITLE
fix: Use transform's exported parser in testUtils

### DIFF
--- a/src/testUtils.js
+++ b/src/testUtils.js
@@ -85,7 +85,9 @@ function runTest(dirName, transformName, options, testFilePrefix, testOptions = 
     testFilePrefix = transformName;
   }
 
-  const extension = extensionForParser(testOptions.parser)
+  // Assumes transform is one level up from __tests__ directory
+  const module = require(path.join(dirName, '..', transformName));
+  const extension = extensionForParser(testOptions.parser || module.parser)
   const fixtureDir = path.join(dirName, '..', '__testfixtures__');
   const inputPath = path.join(fixtureDir, testFilePrefix + `.input.${extension}`);
   const source = fs.readFileSync(inputPath, 'utf8');
@@ -93,8 +95,6 @@ function runTest(dirName, transformName, options, testFilePrefix, testOptions = 
     path.join(fixtureDir, testFilePrefix + `.output.${extension}`),
     'utf8'
   );
-  // Assumes transform is one level up from __tests__ directory
-  const module = require(path.join(dirName, '..', transformName));
   runInlineTest(module, options, {
     path: inputPath,
     source
@@ -140,7 +140,7 @@ exports.defineSnapshotTest = defineSnapshotTest;
  * Handles file-loading boilerplates, using same defaults as defineTest
  */
 function defineSnapshotTestFromFixture(dirName, module, options, testFilePrefix, testName, testOptions = {}) {
-  const extension = extensionForParser(testOptions.parser)
+  const extension = extensionForParser(testOptions.parser || module.parser)
   const fixtureDir = path.join(dirName, '..', '__testfixtures__');
   const inputPath = path.join(fixtureDir, testFilePrefix + `.input.${extension}`);
   const source = fs.readFileSync(inputPath, 'utf8');


### PR DESCRIPTION
### Motivation
The `defineTest` and `defineSnapshotTestFromFixture` functions currently require an explicit `testOptions` when working with Typescript textfixtures, such as [in this example](https://github.com/chimurai/jscodeshift-typescript-example/blob/main/examples/__tests__/reverse-identifiers.spec.ts#L4).

```tsx
const transform: Transform = (file, api) => {
  // ...
}
export default transform;
export const parser = 'ts';
```

```tsx
defineTest(__dirname, 'MyTransform', null, null, { parser: 'ts' });
```

However, when a transform file [exports a ts or tsx parser](https://github.com/facebook/jscodeshift#parser) it would be more convenient if these functions could use that, and avoid needing to write `'ts'` twice across files.

### Changes
When `testOptions.parser` is not explicitly defined, fallback to reading `module.parser`. This mirrors the behaviour seen in [`applyTransform`](https://github.com/facebook/jscodeshift/blob/a614c9b61ad39aa4d2f816329d5eb7cfb99b9136/src/testUtils.js#L22).

```tsx
const transform: Transform = (file, api) => {
  // ...
}
export default transform;
export const parser = 'ts';
```

```tsx
defineTest(__dirname, 'MyTransform');
```

Haven't updated docs, since they already describes these testUtils as making assumptions to reduce configuration. This is how I expected it to work at first reading.