### PR TITLE
chore(github-actions): drop node12 support node18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
- drop node12 support from github-actions (EOL since 2022-04-30)
- add support for node18
