### PR TITLE
chore(github-actions): Use setup-node action to cache dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+          cache: yarn
       - name: Install dependencies
         run: yarn --frozen-lockfile
       - name: Run test


### PR DESCRIPTION
## Description

Updated workflows to cache dependencies using [actions/setup-node](https://github.com/actions/setup-node#caching-global-packages-data). `setup-node@v3` or newer has caching **built-in**.

### About caching workflow dependencies
Jobs on GitHub-hosted runners start in a clean virtual environment and **must download dependencies each time**, causing increased network utilization, longer runtime, and increased cost. To help speed up the time it takes to recreate files like dependencies, GitHub can cache files that frequently use in workflows.

### Solutions
Node.js projects can run faster on GitHub Actions by enabling dependency caching on the [setup-node](https://github.com/actions/setup-node) action. 

### AS-IS

```yml
- name: Use Node.js ${{ matrix.node-version }}
  uses: actions/setup-node@v2
  with:
    node-version: ${{ matrix.node-version }}
```

### TO-BE

```yml
- name: Use Node.js ${{ matrix.node-version }}
  uses: actions/setup-node@v3
  with:
    node-version: ${{ matrix.node-version }}
    cache: yarn
```

> It’s literally a one line change to pass the `cache: yarn` input parameter.

## References

- [https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)