### PR TITLE
Force LF line endings in bin/jscodeshift.js and remove spaces after shebang

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+bin/jscodeshift.js eol=lf

--- a/bin/jscodeshift.js
+++ b/bin/jscodeshift.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node  
+#!/usr/bin/env node
 
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.


### PR DESCRIPTION
This PR forces LF line endings for bin/jscodeshift.js and removes the spaces added after the shebang pragma in #549. I believe the spaces are not necessary as long as the line endings are LF and not CRLF.

See my comment about [Bun](https://bun.sh/) here: https://github.com/facebook/jscodeshift/pull/549#issuecomment-1493142756