### PR TITLE
Update recast for new features and fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "micromatch": "^4.0.4",
     "neo-async": "^2.5.0",
     "node-dir": "^0.1.17",
-    "recast": "^0.23.1",
+    "recast": "^0.23.3",
     "temp": "^0.8.4",
     "write-file-atomic": "^2.3.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1537,9 +1537,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001317, caniuse-lite@^1.0.30001400:
-  version "1.0.30001430"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001430.tgz"
-  integrity sha512-IB1BXTZKPDVPM7cnV4iaKaHxckvdr/3xtctB3f7Hmenx3qYBhGtTZ//7EllK66aKXW98Lx0+7Yr0kxBtIt3tzg==
+  version "1.0.30001515"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001515.tgz"
+  integrity sha512-eEFDwUOZbE24sb+Ecsx3+OvNETqjWIdabMy52oOkIgcUtAsQifjUG9q4U9dgTHJM2mfk4uEPxc0+xuFdJ629QA==
 
 catharsis@^0.9.0:
   version "0.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3322,10 +3322,10 @@ react-is@^18.0.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
-recast@^0.23.1:
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.23.1.tgz#ee415a5561d2f99f02318ea8db81ad3a2267a6ff"
-  integrity sha512-RokaBcoxSjXUDzz1TXSZmZsSW6ZpLmlA3GGqJ8uuTrQ9hZhEz+4Tpsc+gRvYRJ2BU4H+ZyUlg91eSGDw7bwy7g==
+recast@^0.23.3:
+  version "0.23.3"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.23.3.tgz#f205d1f46b2c6f730de413ab18f96c166263d85f"
+  integrity sha512-HbCVFh2ANP6a09nzD4lx7XthsxMOJWKX5pIcUwtLrmeEIl3I0DwjCoVXDE0Aobk+7k/mS3H50FK4iuYArpcT6Q==
   dependencies:
     assert "^2.0.0"
     ast-types "^0.16.1"


### PR DESCRIPTION
Minor version bump to pick up [these changes](https://github.com/benjamn/recast/compare/v0.23.1...v0.23.3) including:
- fix export specifier printing to enable mixed value/type declarations (i.e. `export { someValue, type someType }`)
- fix an issue that moved comments inside a call expression

Also updates `caniuse-lite` as its so old the out-of-date warning breaks tests.