### PR TITLE
Update VSCode launch.json debugging configuration in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,7 +567,10 @@ It's recommended that you set up your codemod project to all debugging via the V
             ],
             "console": "internalConsole",
             "sourceMaps": true,
-            "outFiles": []
+            "outFiles": [],
+            "windows": {
+                "program": "${workspaceRoot}/node_modules/jscodeshift/bin/jscodeshift.js",
+            }
         },
         {
             "name": "Debug All JSCodeshift Jest Tests",


### PR DESCRIPTION
When debugging via the VSCode on Windows 11, I get the following error: 

```
Uncaught SyntaxError C:\~~\node_modules\.bin\jscodeshift:2
basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
          ^^^^^^^

SyntaxError: missing ) after argument list
    at internalCompileFunction (internal/vm:73:18)
    at wrapSafe (internal/modules/cjs/loader:1176:20)
    at <anonymous> (internal/modules/cjs/loader:1218:27)
    at <anonymous> (internal/modules/cjs/loader:1308:10)
    at <anonymous> (internal/modules/cjs/loader:1117:32)
    at <anonymous> (internal/modules/cjs/loader:958:12)
    at executeUserEntryPoint (internal/modules/run_main:81:12)
    at <anonymous> (internal/main/run_main_module:23:47)
vm:73
```

I found the solution [here](https://github.com/krakenjs/zoid-demo/issues/6) and confirmed the new configuration works correctly.
