### PR TITLE
Process all extensions by default

### DIFF
--- a/bin/jscodeshift.js
+++ b/bin/jscodeshift.js
@@ -63,7 +63,6 @@ const parser = require('../src/argsParser')
     },
     extensions: {
       display_index: 3,
-      default: 'js',
       help: 'transform files with these file extensions (comma separated list)',
       metavar: 'EXT',
     },


### PR DESCRIPTION
### Description

Fixes: https://github.com/facebook/jscodeshift/issues/582

### Testing

#### Before

The `ts` files are not processed by default
```console
$ ../jscodeshift/bin/jscodeshift.js example.ts 2>&1 | head -n 1
No files selected, nothing to do.
```

The extensions had to be explicitly passed
```console
$ ../jscodeshift/bin/jscodeshift.js --extensions=ts example.ts 2>&1 | head -n 1
Processing 1 files...
```

By default, the extensions is set to `js`
```console
$ ../jscodeshift/bin/jscodeshift.js --help | grep -A 1 extensions
      --extensions=EXT          transform files with these file extensions (comma separated list)
                                (default: js)
```

#### After

The `ts` files are processed without requiring to pass extensions
```console
$ ../jscodeshift/bin/jscodeshift.js example.ts 2>&1 | head -n 1                
Processing 1 files...
```

The `ts` files are skipped if extensions do not allow it
```console
$ ../jscodeshift/bin/jscodeshift.js --extensions=js example.ts 2>&1 | head -n 1
No files selected, nothing to do.
```

The `ts` files are process if extensions request for it
```console
$ ../jscodeshift/bin/jscodeshift.js --extensions=ts example.ts 2>&1 | head -n 1
Processing 1 files...
```

By default, the extensions is not set
```console
$ ../jscodeshift/bin/jscodeshift.js --help | grep -A 1 extensions
      --extensions=EXT          transform files with these file extensions (comma separated list)
      --(no-)fail-on-error      Return a non-zero code when there are errors
```
