### PR TITLE
Include importAttributes in tsOptions.js

### DIFF
--- a/parser/tsOptions.js
+++ b/parser/tsOptions.js
@@ -31,6 +31,7 @@ module.exports = {
     'exportNamespaceFrom',
     'functionBind',
     'functionSent',
+    'importAttributes,
     'importMeta',
     'nullishCoalescingOperator',
     'numericSeparator',


### PR DESCRIPTION
Allow syntax like `import obj from "./something.json" with { type: "json" };`