### PR TITLE
docs: update getVariableDeclarators description

### DIFF
--- a/website/src/content/docs/build/api-reference.mdx
+++ b/website/src/content/docs/build/api-reference.mdx
@@ -93,14 +93,14 @@ const closestFunction = j.find(j.Identifier).closest(j.FunctionDeclaration);
 
 ### **`getVariableDeclarators`**
 
-Retrieves variable declarators with the specified name from the current collection.
+Retrieves variable declarators from the current collection. If the callback function returns a falsy value, the element is not included in the result.
 
-**Parameters**:`name` (String): The name of the variable to find.
+**Parameters**:`callback` (Function): A function that returns the name of the variable to find.
 
 **Example**:
 
 ```jsx
-const variableDeclarators = j.getVariableDeclarators('myVariable');
+const variableDeclarators = j.find(j.Identifier).getVariableDeclarators(path => path.value.name);
 ```
 
 ### **`findVariableDeclarators` ([source](https://github.com/facebook/jscodeshift/blob/main/src/collections/VariableDeclarator.js))**


### PR DESCRIPTION
The [current description](https://jscodeshift.com/build/api-reference/#getvariabledeclarators) of getVariableDeclarators seems to be inaccurate (it says it takes a string as an argument, like findVariableDeclarators, but the actual argument is a callback), so I fixed it.

See also: https://github.com/facebook/jscodeshift/blob/main/src/collections/Node.js#L103