### PR TITLE
docs: add description for `nodes` api

### DIFF
--- a/website/src/content/docs/build/api-reference.mdx
+++ b/website/src/content/docs/build/api-reference.mdx
@@ -227,6 +227,16 @@ console.log(varCount); // 3
 
 ```
 
+### **`nodes`**
+
+Returns the AST nodes in the collection.
+
+**Example**:
+
+```jsx
+const nodes = j.find(j.VariableDeclaration).nodes();
+```
+
 ### **`paths`**
 
 Returns the paths of the found nodes.


### PR DESCRIPTION
Added missing explanation of the [`nodes`](https://github.com/facebook/jscodeshift/blob/main/src/Collection.js#L158) method.