### PR TITLE
docs: clarify usage options

### DIFF
--- a/website/src/content/docs/run/cli.mdx
+++ b/website/src/content/docs/run/cli.mdx
@@ -26,7 +26,7 @@ jscodeshift [OPTION]... -t TRANSFORM_PATH PATH...
 
 This allows you to specify a path to a transform file and run the transform over the specified `PATH`.
 
-**Option 3: Run from specific transform file:**
+**Option 3: Run from specific transform URL:**
 
 ```bash
 jscodeshift [OPTION]... -t URL PATH...
@@ -34,7 +34,7 @@ jscodeshift [OPTION]... -t URL PATH...
 
 This allows you to specify a URL to a transform file and run the transform over the specified `PATH`.
 
-**Option 4: Run from specific transform file:**
+**Option 4: Apply transform to standard input:**
 
 ```bash
 jscodeshift [OPTION]... --stdin < file_list.txt


### PR DESCRIPTION
The [usage](https://jscodeshift.com/run/cli/#usage) instructions for jscodeshift cli options 2 through 4 were identical, which seemed confusing, so I updated the descriptions for options 3 and 4 to reflect their respective functionalities.