### PR TITLE
Specify node >=16 as supported in package.json engines field

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,5 +67,8 @@
       "sample"
     ]
   },
+  "engines": {
+    "node": ">=16"
+  },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
Fixes: https://github.com/facebook/jscodeshift/issues/606