### PR TITLE
Replace `temp` package with vendored code to avoid deprecated `rimraf` transitive dependency

### DIFF
--- a/bin/__tests__/jscodeshift-test.js
+++ b/bin/__tests__/jscodeshift-test.js
@@ -17,7 +17,6 @@ jest.setTimeout(600000); // 10 minutes
 const child_process = require('child_process');
 const fs = require('fs');
 const path = require('path');
-const temp = require('temp');
 const testUtils = require('../../utils/testUtils');
 const {chdir} = require('process');
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "micromatch": "^4.0.7",
     "neo-async": "^2.5.0",
     "recast": "^0.23.9",
-    "temp": "^0.9.4",
     "write-file-atomic": "^5.0.1"
   },
   "peerDependencies": {

--- a/src/Runner.js
+++ b/src/Runner.js
@@ -190,8 +190,7 @@ function run(transformFile, paths, options) {
           })
           .on('end', () => {
             const ext = path.extname(transformFile);
-            temp.open({ suffix: ext }, (err, info) => {
-              if (err) return reject(err);
+            temp.open({ suffix: ext }).then((info) => {
               fs.write(info.fd, contents, function (err) {
                 if (err) return reject(err);
                 fs.close(info.fd, function(err) {
@@ -199,7 +198,7 @@ function run(transformFile, paths, options) {
                   transform(info.path).then(resolve, reject);
                 });
               });
-            });
+            }, reject);
         })
       })
       .on('error', (e) => {

--- a/src/Runner.js
+++ b/src/Runner.js
@@ -14,8 +14,8 @@ const fs = require('graceful-fs');
 const path = require('path');
 const http = require('http');
 const https = require('https');
-const temp = require('temp');
 const ignores = require('./ignoreFiles');
+const temp = require('./utils/temp');
 
 const availableCpus = Math.max(require('os').cpus().length - 1, 1);
 const CHUNK_SIZE = 50;
@@ -190,7 +190,7 @@ function run(transformFile, paths, options) {
           })
           .on('end', () => {
             const ext = path.extname(transformFile);
-            temp.open({ prefix: 'jscodeshift', suffix: ext }, (err, info) => {
+            temp.open({ suffix: ext }, (err, info) => {
               if (err) return reject(err);
               fs.write(info.fd, contents, function (err) {
                 if (err) return reject(err);

--- a/src/Runner.js
+++ b/src/Runner.js
@@ -160,7 +160,6 @@ function getAllFiles(paths, filter) {
 }
 
 function run(transformFile, paths, options) {
-  let usedRemoteScript = false;
   const cpus = options.cpus ? Math.min(availableCpus, options.cpus) : availableCpus;
   const extensions =
     options.extensions && options.extensions.split(',').map(ext => '.' + ext);
@@ -179,7 +178,6 @@ function run(transformFile, paths, options) {
   }
 
   if (/^http/.test(transformFile)) {
-    usedRemoteScript = true;
     return new Promise((resolve, reject) => {
       // call the correct `http` or `https` implementation
       (transformFile.indexOf('https') !== 0 ?  http : https).get(transformFile, (res) => {
@@ -308,9 +306,6 @@ function run(transformFile, paths, options) {
             if (options.failOnError && fileCounters.error > 0) {
               process.exit(1);
             }
-          }
-          if (usedRemoteScript) {
-            temp.cleanupSync();
           }
           return Object.assign({
             stats: statsCounter,

--- a/src/utils/temp.js
+++ b/src/utils/temp.js
@@ -34,17 +34,11 @@ function generateName(suffix) {
   );
 }
 
-exports.open = function open(opts, callback) {
+exports.open = async function open(opts) {
   if (!opts) opts = {};
   const target = generateName(opts.suffix);
-  return new Promise((resolve, reject) => {
-    fs.open(target, RDWR_EXCL, 0o600, (error, fd) => {
-      const result = { path: target, fd };
-      if (callback) callback(error, result);
-      if (error) return reject(error);
-      resolve(result);
-    });
-  });
+  const fd = await fs.promises.open(target, RDWR_EXCL, 0o600);
+  return { path: target, fd };
 };
 
 exports.openSync = function open(opts) {

--- a/src/utils/temp.js
+++ b/src/utils/temp.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) 2010-2014 Bruce Williams
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const constants = require('constants');
+
+const RDWR_EXCL = constants.O_CREAT | constants.O_TRUNC | constants.O_RDWR | constants.O_EXCL;
+const tempDir = path.resolve(os.tmpdir());
+
+function generateName(suffix) {
+  const now = new Date();
+  return path.join(
+    tempDir,
+    [
+      'jscodeshift',
+      now.getFullYear(),
+      now.getMonth(),
+      now.getDate(),
+      '-',
+      process.pid,
+      '-',
+      (Math.random() * 0x100000000 + 1).toString(36),
+      suffix || '',
+    ].join('')
+  );
+}
+
+exports.open = function open(opts, callback) {
+  if (!opts) opts = {};
+  const target = generateName(opts.suffix);
+  return new Promise((resolve, reject) => {
+    fs.open(target, RDWR_EXCL, 0o600, (error, fd) => {
+      if (!error) {
+        deleteFileOnExit(target);
+      }
+      const result = { path: target, fd };
+      if (callback) callback(error, result);
+      if (error) return reject(error);
+      resolve(result);
+    });
+  });
+};
+
+exports.openSync = function open(opts) {
+  if (!opts) opts = {};
+  const target = generateName(opts.suffix);
+  const fd = fs.openSync(target, RDWR_EXCL, 0o600);
+  return { path: target, fd };
+};

--- a/src/utils/temp.js
+++ b/src/utils/temp.js
@@ -37,8 +37,8 @@ function generateName(suffix) {
 exports.open = async function open(opts) {
   if (!opts) opts = {};
   const target = generateName(opts.suffix);
-  const fd = await fs.promises.open(target, RDWR_EXCL, 0o600);
-  return { path: target, fd };
+  const file = await fs.promises.open(target, RDWR_EXCL, 0o600);
+  return { path: target, fd: file.fd };
 };
 
 exports.openSync = function open(opts) {

--- a/src/utils/temp.js
+++ b/src/utils/temp.js
@@ -39,9 +39,6 @@ exports.open = function open(opts, callback) {
   const target = generateName(opts.suffix);
   return new Promise((resolve, reject) => {
     fs.open(target, RDWR_EXCL, 0o600, (error, fd) => {
-      if (!error) {
-        deleteFileOnExit(target);
-      }
       const result = { path: target, fd };
       if (callback) callback(error, result);
       if (error) return reject(error);

--- a/utils/testUtils.js
+++ b/utils/testUtils.js
@@ -10,7 +10,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const temp = require('temp');
+const temp = require('../src/utils/temp');
 
 function renameFileTo(oldPath, newFilename, extension = '') {
   const projectPath = path.dirname(oldPath);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2429,18 +2429,6 @@ minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.6:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
-  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
-
-mkdirp@^0.5.1:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
-  integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
-  dependencies:
-    minimist "^1.2.6"
-
 mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
@@ -2738,13 +2726,6 @@ rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
-rimraf@~2.6.2:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
-  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
-  dependencies:
-    glob "^7.1.3"
-
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -2903,14 +2884,6 @@ supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
-
-temp@^0.9.4:
-  version "0.9.4"
-  resolved "https://registry.yarnpkg.com/temp/-/temp-0.9.4.tgz#cd20a8580cb63635d0e4e9d4bd989d44286e7620"
-  integrity sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==
-  dependencies:
-    mkdirp "^0.5.1"
-    rimraf "~2.6.2"
 
 test-exclude@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
This is simply to avoid the dependency chain on `rimraf` via `temp@0.8.4 -> rimraf@2.6.3`, which has been deprecated. The [`temp` package](https://github.com/bruce/node-temp) hasn't seen a release in a while, and minimal functionality is used from it. The `temp.track` functionality also doesn't seem to be used, which would make it pretty trivial to vendor the code.

Switching to alternatives like `tempy` likely isn't attractive either since it's ESM-only while `jscodeshift` is not. Older versions of `tempy` also depend transitively on deprecated versions of `rimraf`.

Tests pass and cover changes as-is.

**Note:** The vendored code has an added copyright notice line for `node-temp`.