### PR TITLE
Fix renameTo false positive for JSX tags

### DIFF
--- a/src/collections/VariableDeclarator.js
+++ b/src/collections/VariableDeclarator.js
@@ -157,6 +157,15 @@ const transformMethods = {
             return false;
           }
 
+          if (
+            (types.JSXOpeningElement.check(parent) || types.JSXClosingElement.check(parent)) &&
+            parent.name === path.node &&
+            /^[a-z]/.test(path.node.name)
+          ) {
+            // <oldName></oldName>
+            return false;
+          }
+
           return true;
         })
         .forEach(function(path) {

--- a/src/collections/__tests__/VariableDeclarator-test.js
+++ b/src/collections/__tests__/VariableDeclarator-test.js
@@ -171,6 +171,39 @@ describe('VariableDeclarators', function() {
       expect(identifiers.length).toBe(1);
     });
 
+    it('does not rename JSX open and closing tags that start with a lowercase letter', function () {
+      nodes = [recast.parse([
+        'var span = useRef(null);',
+        'var element = <span ref={span}></span>;',
+      ].join('\n'), {parser: getParser()}).program];
+
+      Collection.fromNodes(nodes)
+        .findVariableDeclarators('span')
+        .renameTo('spanRef');
+
+      const identifiers = Collection.fromNodes(nodes)
+        .find(types.JSXIdentifier, { name: 'spanRef' });
+
+      expect(identifiers.length).toBe(0);
+    });
+
+    it('does rename JSX open and closing tags that are capitalized', function () {
+      nodes = [recast.parse([
+        'var Span = require("./Span");',
+        'var span = useRef(null);',
+        'var element = <Span ref={span}></Span>;',
+      ].join('\n'), {parser: getParser()}).program];
+
+      Collection.fromNodes(nodes)
+        .findVariableDeclarators('Span')
+        .renameTo('SpanComponent');
+
+      const identifiers = Collection.fromNodes(nodes)
+        .find(types.JSXIdentifier, { name: 'SpanComponent' });
+
+      expect(identifiers.length).toBe(2);
+    });
+
     describe('parsing with bablylon', function() {
       it('does not rename object property', function () {
         nodes = [


### PR DESCRIPTION
This fixes an edge case that we ran into where JSX tags are inadvertently renamed when they are "built-in" components like `<div>` or `<span>`. We should only consider capitalized tags as variable references (see [React docs](https://legacy.reactjs.org/docs/jsx-in-depth.html#user-defined-components-must-be-capitalized)). For this PR I used the the [same regex](https://github.com/babel/babel/blame/368b512229d41147f5ea835a3dd7d5a256a5764e/packages/babel-types/src/validators/react/isCompatTag.ts#L3) as the JSX Babel transform for consistency. 

I understand that this logic is React-specific and there could be JSX usage that does not follow these conventions. Ideally this could be configurable.  




