### PR TITLE
chore: replace `temp` library with `tmp`

### DIFF
--- a/bin/__tests__/jscodeshift-test.js
+++ b/bin/__tests__/jscodeshift-test.js
@@ -17,9 +17,7 @@ jest.setTimeout(600000); // 10 minutes
 const child_process = require('child_process');
 const fs = require('fs');
 const path = require('path');
-const temp = require('temp');
 const testUtils = require('../../utils/testUtils');
-const {chdir} = require('process');
 
 const createTransformWith = testUtils.createTransformWith;
 const createTempFileWith = testUtils.createTempFileWith;

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "neo-async": "^2.5.0",
     "picocolors": "^1.0.1",
     "recast": "^0.23.9",
-    "temp": "^0.9.4",
+    "tmp": "^0.2.3",
     "write-file-atomic": "^5.0.1"
   },
   "peerDependencies": {

--- a/src/Runner.js
+++ b/src/Runner.js
@@ -14,8 +14,10 @@ const fs = require('graceful-fs');
 const path = require('path');
 const http = require('http');
 const https = require('https');
-const tmp = require('tmp');
 const ignores = require('./ignoreFiles');
+
+const tmp = require('tmp');
+tmp.setGracefulCleanup();
 
 const availableCpus = Math.max(require('os').cpus().length - 1, 1);
 const CHUNK_SIZE = 50;

--- a/src/Runner.js
+++ b/src/Runner.js
@@ -14,7 +14,7 @@ const fs = require('graceful-fs');
 const path = require('path');
 const http = require('http');
 const https = require('https');
-const temp = require('temp');
+const tmp = require('tmp');
 const ignores = require('./ignoreFiles');
 
 const availableCpus = Math.max(require('os').cpus().length - 1, 1);
@@ -190,13 +190,13 @@ function run(transformFile, paths, options) {
           })
           .on('end', () => {
             const ext = path.extname(transformFile);
-            temp.open({ prefix: 'jscodeshift', suffix: ext }, (err, info) => {
+            tmp.file({ prefix: 'jscodeshift', postfix: ext }, (err, path, fd) => {
               if (err) return reject(err);
-              fs.write(info.fd, contents, function (err) {
+              fs.write(fd, contents, function (err) {
                 if (err) return reject(err);
-                fs.close(info.fd, function(err) {
+                fs.close(fd, function(err) {
                   if (err) return reject(err);
-                  transform(info.path).then(resolve, reject);
+                  transform(path).then(resolve, reject);
                 });
               });
             });

--- a/src/Runner.js
+++ b/src/Runner.js
@@ -160,7 +160,6 @@ function getAllFiles(paths, filter) {
 }
 
 function run(transformFile, paths, options) {
-  let usedRemoteScript = false;
   const cpus = options.cpus ? Math.min(availableCpus, options.cpus) : availableCpus;
   const extensions =
     options.extensions && options.extensions.split(',').map(ext => '.' + ext);
@@ -179,7 +178,6 @@ function run(transformFile, paths, options) {
   }
 
   if (/^http/.test(transformFile)) {
-    usedRemoteScript = true;
     return new Promise((resolve, reject) => {
       // call the correct `http` or `https` implementation
       (transformFile.indexOf('https') !== 0 ?  http : https).get(transformFile, (res) => {
@@ -309,9 +307,6 @@ function run(transformFile, paths, options) {
             if (options.failOnError && fileCounters.error > 0) {
               process.exit(1);
             }
-          }
-          if (usedRemoteScript) {
-            temp.cleanupSync();
           }
           return Object.assign({
             stats: statsCounter,

--- a/utils/testUtils.js
+++ b/utils/testUtils.js
@@ -10,7 +10,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const temp = require('temp');
+const tmp = require('tmp');
 
 function renameFileTo(oldPath, newFilename, extension = '') {
   const projectPath = path.dirname(oldPath);
@@ -21,12 +21,12 @@ function renameFileTo(oldPath, newFilename, extension = '') {
 }
 
 function createTempFileWith(content, filename, extension) {
-  const info = temp.openSync({ suffix: extension });
-  let filePath = info.path;
+  const info = tmp.fileSync({ postfix: extension });
+  let filePath = info.name;
   fs.writeSync(info.fd, content);
   fs.closeSync(info.fd);
   if (filename) {
-    filePath = renameFileTo(filePath, filename, extension);
+    filePath = renameFileTo(info.name, filename, extension);
   }
   return filePath;
 }

--- a/utils/testUtils.js
+++ b/utils/testUtils.js
@@ -26,7 +26,7 @@ function createTempFileWith(content, filename, extension) {
   fs.writeSync(info.fd, content);
   fs.closeSync(info.fd);
   if (filename) {
-    filePath = renameFileTo(info.name, filename, extension);
+    filePath = renameFileTo(filePath, filename, extension);
   }
   return filePath;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2429,18 +2429,6 @@ minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.6:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
-  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
-
-mkdirp@^0.5.1:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
-  integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
-  dependencies:
-    minimist "^1.2.6"
-
 mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
@@ -2738,13 +2726,6 @@ rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
-rimraf@~2.6.2:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
-  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
-  dependencies:
-    glob "^7.1.3"
-
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -2904,14 +2885,6 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-temp@^0.9.4:
-  version "0.9.4"
-  resolved "https://registry.yarnpkg.com/temp/-/temp-0.9.4.tgz#cd20a8580cb63635d0e4e9d4bd989d44286e7620"
-  integrity sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==
-  dependencies:
-    mkdirp "^0.5.1"
-    rimraf "~2.6.2"
-
 test-exclude@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-6.0.0.tgz#04a8698661d805ea6fa293b6cb9e63ac044ef15e"
@@ -2930,6 +2903,11 @@ tiny-invariant@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.3.tgz#46680b7a873a0d5d10005995eb90a70d74d60127"
   integrity sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==
+
+tmp@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.3.tgz#eb783cc22bc1e8bebd0671476d46ea4eb32a79ae"
+  integrity sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==
 
 tmpl@1.0.5:
   version "1.0.5"


### PR DESCRIPTION
This PR would fix the deprecation warnings that appear during the installation of `jscodeshift`'s peer dependencies.
An example of such warnings can be reproduced by installing the `jscodeshift` CLI tool globally (`npm i -g jscodeshift`) or by installing any other package that has jscodeshift as a dependency. For instance, this is what the error looks like in my shell:
<img width="1196" alt="Screenshot 2024-09-27 at 23 16 00" src="https://github.com/user-attachments/assets/25f8325b-ab4d-43a6-b77a-c4dcf56d1d28">

The testing of this PR was done by performing the following steps:
- Packing the app with updated dependencies into a tarball using `yarn pack`
- Installing it globally via `npm i -g ./path/to/tarball.tgz`

The results are as shown:
<img width="407" alt="Screenshot 2024-09-27 at 23 16 08" src="https://github.com/user-attachments/assets/5f4640c7-b781-46e5-a28e-c0404066f42b">

After this PR is merged, a release will be required to fix the error for all of the dependants.