### PR TITLE
feat: add individual file results to Runner output

### DIFF
--- a/src/Runner.js
+++ b/src/Runner.js
@@ -166,6 +166,7 @@ function run(transformFile, paths, options) {
   const extensions =
     options.extensions && options.extensions.split(',').map(ext => '.' + ext);
   const fileCounters = {error: 0, ok: 0, nochange: 0, skip: 0};
+  const fileResults = [];
   const statsCounter = {};
   const startTime = process.hrtime();
 
@@ -275,6 +276,7 @@ function run(transformFile, paths, options) {
             switch (message.action) {
               case 'status':
                 fileCounters[message.status] += 1;
+                fileResults.push({file: message.file, status: message.status});
                 log[message.status](lineBreak(message.msg), options.verbose);
                 break;
               case 'update':
@@ -312,7 +314,8 @@ function run(transformFile, paths, options) {
           }
           return Object.assign({
             stats: statsCounter,
-            timeElapsed: timeElapsed
+            timeElapsed: timeElapsed,
+            results: fileResults
           }, fileCounters);
         })
       );

--- a/src/Worker.js
+++ b/src/Worker.js
@@ -107,7 +107,7 @@ function free() {
 
 function updateStatus(status, file, msg) {
   msg = msg ? file + ' ' + msg : file;
-  notify({action: 'status', status: status, msg: msg});
+  notify({action: 'status', status: status, msg: msg, file: file});
 }
 
 function report(file, msg) {


### PR DESCRIPTION
This PR adds a list of the individual file statuses to the result object of `src/Runner.js`. It is helpful for post-processing tasks e.g. identifying the files that were changed and updating their related project `package.json` files.