### PR TITLE
Enable async tranformers in test utils

### DIFF
--- a/.changeset/polite-lizards-know.md
+++ b/.changeset/polite-lizards-know.md
@@ -1,0 +1,5 @@
+---
+"jscodeshift": patch
+---
+
+Enable async tranformers in test utils.

--- a/README.md
+++ b/README.md
@@ -536,6 +536,7 @@ defineSnapshotTestFromFixture(__dirname, transform, transformOptions, 'FirstFixt
 
 Executes your transform using the options and the input given and returns the result.
 This function is used internally by the other helpers, but it can prove useful in other cases.
+(bear in mind the `transform` module can be asynchronous. In that case, `applyTransform` will return a `Promise` with the transformed code. Otherwise, it will directly return the transformed code as a `string`).
 
 ```js
 const applyTransform = require('jscodeshift/dist/testUtils').applyTransform;

--- a/src/__testfixtures__/test-async-transform.input.js
+++ b/src/__testfixtures__/test-async-transform.input.js
@@ -1,0 +1,1 @@
+export const sum = (a, b) => a + b;

--- a/src/__testfixtures__/test-async-transform.js
+++ b/src/__testfixtures__/test-async-transform.js
@@ -1,0 +1,11 @@
+const synchronousTestTransform = (fileInfo, api, options) => {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve(api.jscodeshift(fileInfo.source)
+        .findVariableDeclarators('sum')
+        .renameTo('addition')
+        .toSource());
+    }, 100);
+  });
+}
+module.exports = synchronousTestTransform;

--- a/src/__testfixtures__/test-async-transform.output.js
+++ b/src/__testfixtures__/test-async-transform.output.js
@@ -1,0 +1,1 @@
+export const addition = (a, b) => a + b;

--- a/src/__testfixtures__/test-sync-transform.input.js
+++ b/src/__testfixtures__/test-sync-transform.input.js
@@ -1,0 +1,1 @@
+export const sum = (a, b) => a + b;

--- a/src/__testfixtures__/test-sync-transform.js
+++ b/src/__testfixtures__/test-sync-transform.js
@@ -1,0 +1,7 @@
+const synchronousTestTransform = (fileInfo, api, options) => {
+  return api.jscodeshift(fileInfo.source)
+    .findVariableDeclarators('sum')
+    .renameTo('addition')
+    .toSource();
+}
+module.exports = synchronousTestTransform;

--- a/src/__testfixtures__/test-sync-transform.output.js
+++ b/src/__testfixtures__/test-sync-transform.output.js
@@ -1,0 +1,1 @@
+export const addition = (a, b) => a + b;

--- a/src/__tests__/__snapshots__/testUtils-test.js.snap
+++ b/src/__tests__/__snapshots__/testUtils-test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`testUtils async should run async defineSnapshotTest 1`] = `"export const addition = (a, b) => a + b;"`;
+
+exports[`testUtils async should run async defineSnapshotTestFromFixture 1`] = `"export const addition = (a, b) => a + b;"`;
+
+exports[`testUtils async should run snapshot test 1`] = `"export const addition = (a, b) => a + b;"`;
+
+exports[`testUtils synchronous should run snapshot test 1`] = `"export const addition = (a, b) => a + b;"`;
+
+exports[`testUtils synchronous should run sync defineSnapshotTest 1`] = `"export const addition = (a, b) => a + b;"`;
+
+exports[`testUtils synchronous should run sync defineSnapshotTestFromFixture 1`] = `"export const addition = (a, b) => a + b;"`;

--- a/src/__tests__/testUtils-test.js
+++ b/src/__tests__/testUtils-test.js
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const testSyncTransform = require('../__testfixtures__/test-sync-transform');
+const testAsyncTransform = require('../__testfixtures__/test-async-transform');
+
+const testUtils = require('../testUtils');
+
+const testInputSource = 'export const sum = (a, b) => a + b;';
+const expectedInlineOutput = 'export const addition = (a, b) => a + b;';
+
+const getModuleToTransform = () => {
+  const moduleToTransformPath = path.join(__dirname, '..', '__testfixtures__', 'test-sync-transform.input.js');
+  const source = fs.readFileSync(moduleToTransformPath, 'utf8');
+  return {
+    path: moduleToTransformPath,
+    source,
+  }
+}
+
+describe('testUtils', () => {
+  describe('synchronous', () => {
+    it('should apply transformation', () => {
+      const moduleToTransform = getModuleToTransform();
+      const transformedCode = testUtils.applyTransform(testSyncTransform, null, moduleToTransform);
+
+      expect(transformedCode).not.toMatch(/sum/);
+      expect(transformedCode).toMatch(/addition/);
+    });
+
+    it('should run test', () => {
+      testUtils.runTest(
+        __dirname,
+        path.join('__testfixtures__',
+        'test-sync-transform'),
+        null,
+        'test-sync-transform'
+      );
+    });
+
+    it ('should run snapshot test', () => {
+      const moduleToTransform = getModuleToTransform();
+      testUtils.runSnapshotTest(testSyncTransform, null, moduleToTransform);
+    });
+
+    it('should run inline test', () => {
+      const moduleToTransform = getModuleToTransform();
+      testUtils.runInlineTest(testSyncTransform, null, moduleToTransform, expectedInlineOutput);
+    });
+
+    testUtils.defineTest(
+      __dirname,
+      path.join('__testfixtures__', 'test-sync-transform'),
+      null,
+      'test-sync-transform'
+    );
+
+    testUtils.defineInlineTest(
+      testSyncTransform,
+      null,
+      testInputSource,
+      expectedInlineOutput,
+      'should run sync defineInlineTest'
+    );
+
+    testUtils.defineSnapshotTest(
+      testSyncTransform,
+      null,
+      testInputSource,
+      'should run sync defineSnapshotTest'
+    );
+
+    testUtils.defineSnapshotTestFromFixture(
+      __dirname,
+      testSyncTransform,
+      null,
+      'test-sync-transform',
+      'should run sync defineSnapshotTestFromFixture'
+    );
+  });
+
+  describe('async', () => {
+    it('should apply transformation', async () => {
+      const moduleToTransform = getModuleToTransform();
+      const transformedCode = await testUtils.applyTransform(testAsyncTransform, null, moduleToTransform);
+
+      expect(transformedCode).not.toMatch(/sum/);
+      expect(transformedCode).toMatch(/addition/);
+    });
+
+    it('should run test', () => {
+      return testUtils.runTest(__dirname, path.join('__testfixtures__', 'test-async-transform'), null, 'test-async-transform');
+    });
+
+    it ('should run snapshot test', () => {
+      const moduleToTransform = getModuleToTransform();
+      return testUtils.runSnapshotTest(testAsyncTransform, null, moduleToTransform);
+    });
+
+    it('should run inline test', () => {
+      const moduleToTransform = getModuleToTransform();
+      return testUtils.runInlineTest(testAsyncTransform, null, moduleToTransform, expectedInlineOutput);
+    });
+
+    testUtils.defineTest(
+      __dirname,
+      path.join('__testfixtures__', 'test-async-transform'),
+      null,
+      'test-async-transform'
+    );
+
+    testUtils.defineInlineTest(
+      testAsyncTransform,
+      null,
+      testInputSource,
+      expectedInlineOutput,
+      'should run async defineInlineTest'
+    );
+
+    testUtils.defineSnapshotTest(
+      testAsyncTransform,
+      null,
+      testInputSource,
+      'should run async defineSnapshotTest'
+    );
+
+    testUtils.defineSnapshotTestFromFixture(
+      __dirname,
+      testSyncTransform,
+      null,
+      'test-async-transform',
+      'should run async defineSnapshotTestFromFixture'
+    );
+  });
+});


### PR DESCRIPTION
Currently the available [test utilities](https://github.com/facebook/jscodeshift?tab=readme-ov-file#unit-testing) exposed by the library helps a lot when developers need to test their custom transformation but they only support synchronous transformations.

I've seen others also asking about this feature ([reference1](https://github.com/facebook/jscodeshift/issues/516), [reference 2](https://github.com/facebook/jscodeshift/issues/454)) so I've decided to give it a try and update those utilities to be able to manage both sync and async transformations.

Please let me know if this is something that could potentially be adopted by `jscodeshift`.

Thanks.