### PR TITLE
docs: add missing `findImportDeclarations` method to Collection API documentation

### DIFF
--- a/website/src/content/docs/build/api-reference.mdx
+++ b/website/src/content/docs/build/api-reference.mdx
@@ -71,6 +71,19 @@ Finds nodes that match the provided type.
 const variableDeclarations = j.find(j.VariableDeclaration);
 ```
 
+### **`findImportDeclarations`**
+
+Finds all ImportDeclarations optionally filtered by name.
+
+**Parameters**: `sourcePath` (String).
+
+**Example**:
+
+```jsx
+const routerImports = j.findImportDeclarations('react-router-dom');
+
+```
+
 ### **`closestScope`**
 
 Finds the closest enclosing scope of a node. Useful for determining the scope context of variables and functions.


### PR DESCRIPTION
This PR updates the API documentation to include the `findImportDeclarations` method for Collections.

The method `findImportDeclarations` already exists in the jscodeshift codebase, but is currently missing from the official documentation.  
This update documents its usage, parameters, and provides a usage example.

Adding this entry improves the discoverability of existing API features and enhances developer experience (DX).


Thanks for maintaining jscodeshift!
