### PR TITLE
Add iterator implementation to Collections

### DIFF
--- a/.changeset/metal-walls-switch.md
+++ b/.changeset/metal-walls-switch.md
@@ -1,0 +1,7 @@
+---
+"jscodeshift": minor
+---
+
+Add iterator implementation to Collections
+
+ES6 iterators support the new for..of syntax. Since a Collection wraps an Array, we can lean on ECMAScript's new iterator delegation.

--- a/src/Collection.js
+++ b/src/Collection.js
@@ -65,6 +65,15 @@ class Collection {
   }
 
   /**
+   * Implements for-of iterator semantic for node paths of the collection.
+   *
+   * @returns {Iterator<import("ast-types").NodePath>}
+   */
+  *[Symbol.iterator]() {
+    yield* this.__paths;
+  }
+
+  /**
    * Executes callback for each node/path in the collection.
    *
    * @param {function} callback

--- a/src/__tests__/Collection-test.js
+++ b/src/__tests__/Collection-test.js
@@ -214,6 +214,20 @@ describe('Collection API', function() {
 
     });
 
+    describe('iterator', () => {
+      it('provides an iterator over the collection', () => {
+        const each = jest.fn();
+        const collection = Collection.fromNodes(nodes);
+        for (const path of collection) {
+          each(path);
+        }
+
+        expect(each.mock.calls.length).toBe(2);
+        expect(each.mock.calls[0][0].value).toBe(nodes[0]);
+        expect(each.mock.calls[1][0].value).toBe(nodes[1]);
+      });
+    });
+
     describe('forEach', function() {
       it('lets you iterate over each element of an collection', function() {
         const each = jest.fn();


### PR DESCRIPTION
ES6 iterators support the new for..of syntax. Since a `Collection` wraps an `Array`, we can lean on ECMAScript's new iterator delegation.

Resolve #679

I am working on [esupgrade](https://github.com/codingjoe/esupgrade) a tool to upgrade JS/TS code to widely available ECMAScript features. It's built on this wonderful tool. I'd really love to keep esupgrade's code base up to date too, and using for..of loops and generators would help tremendously.

Thanks for your consideration and for publishing this under a free license <3