### PR TITLE
chore: replace micromatch with picomatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@babel/register": "^7.24.6",
     "flow-parser": "0.*",
     "graceful-fs": "^4.2.4",
-    "micromatch": "^4.0.7",
+    "picomatch": "^4.0.2",
     "neo-async": "^2.5.0",
     "picocolors": "^1.0.1",
     "recast": "^0.23.11",

--- a/src/ignoreFiles.js
+++ b/src/ignoreFiles.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const fs = require('fs');
-const mm = require('micromatch');
+const picomatch = require('picomatch');
 
 const matchers = [];
 
@@ -59,7 +59,7 @@ function addIgnoreFromFile(input) {
 }
 
 function shouldIgnore(path) {
-  const matched = matchers.length ? mm.isMatch(path, matchers, { dot:true }) : false;
+  const matched = matchers.length ? picomatch.isMatch(path, matchers, { dot:true }) : false;
   return matched;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2851,7 +2851,7 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.7:
+micromatch@^4.0.2, micromatch@^4.0.4:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
   integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
@@ -3072,6 +3072,11 @@ picomatch@^2.0.4, picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+picomatch@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.3.tgz#796c76136d1eead715db1e7bad785dedd695a042"
+  integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
 
 pify@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
## Summary

Replace `micromatch` with `picomatch` for glob matching in `ignoreFiles.js`.

- Only `micromatch.isMatch()` was used, which maps directly to `picomatch.isMatch()` (identical API — picomatch is the engine inside micromatch)
- `picomatch` has zero dependencies and a smaller install size (83 kB vs 235 kB)
- Part of the [e18e ecosystem cleanup initiative](https://e18e.dev/)

Closes #603

## Test plan

- [x] All 18 test suites pass (207 tests, 8 snapshots)
- [x] Verified `picomatch.isMatch()` accepts the same signature: `(string, patterns, options)` including array patterns
- [x] `{ dot: true }` option is supported by picomatch