### PR TITLE
Security: Automatic Babel transpilation executes untrusted transform code in-process

### DIFF
--- a/src/Worker.js
+++ b/src/Worker.js
@@ -29,6 +29,8 @@ let notify;
 let transform;
 let parserFromTransform;
 
+const allowUnsafeBabel = process.env.JSCODESHIFT_ALLOW_UNSAFE_BABEL === '1';
+
 if (module.parent) {
   emitter = new EventEmitter();
   emitter.send = (data) => { run(data); };
@@ -53,6 +55,9 @@ function prepareJscodeshift(options) {
 
 function setup(tr, babel) {
   if (babel === 'babel') {
+    if (!allowUnsafeBabel) {
+      throw new Error('Babel transform loading is disabled. Set JSCODESHIFT_ALLOW_UNSAFE_BABEL=1 only for trusted transforms.');
+    }
     const presets = [];
     if (presetEnv) {
       presets.push([


### PR DESCRIPTION
## Problem

When Babel mode is enabled, the worker uses `@babel/register` and then `require(tr)` to load and execute the transform module. In multi-tenant or service deployments, a user-provided transform path results in arbitrary code execution with worker privileges, including filesystem and network access.

**Severity**: `high`
**File**: `src/Worker.js`

## Solution

Treat transforms as untrusted code: run in a hardened sandbox (separate container/user, seccomp/AppArmor, read-only FS where possible, blocked outbound network), or require signed/approved transforms. Consider disabling Babel/register for untrusted scenarios.

## Changes

- `src/Worker.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
