### PR TITLE
fix: resolve #463 — Tests fail without any message if there are type errors

### DIFF
--- a/utils/testUtils.js
+++ b/utils/testUtils.js
@@ -47,3 +47,17 @@ function getFileContent(filePath) {
   return fs.readFileSync(filePath).toString();
 }
 exports.getFileContent = getFileContent;
+
+function runTest(transformName, { jscodeshift = require('jscodeshift'), ...options } = {}) {
+  const dirName = path.dirname(require.resolve('jscodeshift'));
+  let module;
+  try {
+    module = require(path.join(dirName, '..', transformName));
+  } catch (e) {
+    console.log('Error importing module', e);
+  }
+  const j = jscodeshift;
+  return (input, { dry, bench } = {}) =>
+    j(input, { dry, ...options, jscodeshift: j, babel: true, ...module }, { bench });
+}
+exports.runTest = runTest;


### PR DESCRIPTION
## Summary

fix: resolve #463 — Tests fail without any message if there are type errors

## Problem

**Severity**: `Medium` | **File**: `utils/testUtils.js`

The issue is that when testing TypeScript transforms with type errors, the tests fail silently without any error message. The `runTest` function imports the transform module using `require()`, but if there are TypeScript compilation errors (type errors), the require fails without providing any useful error message to the user. This makes debugging TypeScript issues very difficult.

## Solution

Modify the `runTest` function in `utils/testUtils.js` to wrap the `require(path.join(dirName, '..', transformName))` call in a try-catch block. When an error is caught, log the error message with `console.log('Error importing module', e)` before allowing the test to proceed. This will ensure that even if the module has TypeScript type errors, the error will be visible to the user instead of the test just failing silently.

## Changes

- `utils/testUtils.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v6.0.0*