### PR TITLE
fix: resolve #206 — change index.js point to './src/core' break test cases follow README

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,3 +7,18 @@
  */
 
 module.exports = require('./src/core');
+module.exports.run = require('./src/core').run;
+module.exports.transform = require('./src/core').transform;
+module.exports.defineFixture = require('./src/core').defineFixture;
+module.exports.registerConfig = require('./src/core').registerConfig;
+module.exports.printResults = require('./src/core').printResults;
+module.exports.parseArgs = require('./src/core').parseArgs;
+module.exports.createExtension = require('./src/core').createExtension;
+module.exports.builtinDecorators = require('./src/core').builtinDecorators;
+module.exports.builtinTransforms = require('./src/core').builtinTransforms;
+module.exports.builtinParsers = require('./src/core').builtinParsers;
+module.exports.ParsingSourceError = require('./src/core').ParsingSourceError;
+module.exports.InvalidSourceError = require('./src/core').InvalidSourceError;
+module.exports.SyntaxError = require('./src/core').SyntaxError;
+module.exports.Suite = require('./src/core').Suite;
+module.exports.Test = require('./src/core').Test;

--- a/src/core.js
+++ b/src/core.js
@@ -180,4 +180,6 @@ function enrichCore(core, parser) {
   return core;
 }
 
-module.exports = enrichCore(core, getParser());
+const enrichedCore = enrichCore(core, getParser());
+enrichedCore.registerMethods = Collection.registerMethods;
+module.exports = enrichedCore;


### PR DESCRIPTION
## Summary

fix: resolve #206 — change index.js point to './src/core' break test cases follow README

## Problem

**Severity**: `Medium` | **File**: `index.js`

The main entry point (index.js) changed to simply re-export from './src/core'. This breaks backwards compatibility for users who were importing from the main package entry point (e.g., `require('jscodeshift')`).

## Solution

Combined multi-file contribution:

- Docs: index.js re-exports from './src/core'
- Docs: Core module exports
- Docs: testUtils is not re-exported from core
- Docs: Check what core.js exports and includes

Files changed: index.js, src/core.js

## Changes

- `index.js` (modified)
- `src/core.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v6.0.0*