### PR TITLE
Fix ignore patterns not matching relative source paths starting with ../ (#556)

### DIFF
--- a/.changeset/ignore-relative-parent-paths.md
+++ b/.changeset/ignore-relative-parent-paths.md
@@ -1,0 +1,7 @@
+---
+"jscodeshift": patch
+---
+
+Fix `--ignore-pattern` not matching files when the source path is relative and starts with `../` (or `./`)
+
+Ignore patterns such as `**/node_modules/**` were silently skipped for files enumerated from a relative source path like `../app/src`, because picomatch's `**` wildcard does not match across a leading `../`/`./` traversal segment. The path is now also matched with any leading traversal prefix stripped, so ignore behavior is consistent for relative and absolute source paths.

--- a/src/__tests__/ignoreFiles-test.js
+++ b/src/__tests__/ignoreFiles-test.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/*global jest, describe, it, expect, beforeEach*/
+
+'use strict';
+
+describe('ignoreFiles', function() {
+  let ignores;
+
+  beforeEach(function() {
+    // `ignoreFiles` keeps the registered matchers in module-level state, so
+    // reset the module registry to get a clean matcher list for each test.
+    jest.resetModules();
+    ignores = require('../ignoreFiles');
+  });
+
+  it('does not ignore anything when no patterns were added', function() {
+    expect(ignores.shouldIgnore('src/node_modules/foo.js')).toBe(false);
+  });
+
+  describe('with a glob pattern', function() {
+    beforeEach(function() {
+      ignores.add('**/node_modules/**');
+    });
+
+    it('ignores matching plain relative and absolute paths', function() {
+      expect(ignores.shouldIgnore('src/node_modules/foo.js')).toBe(true);
+      expect(ignores.shouldIgnore('/abs/src/node_modules/foo.js')).toBe(true);
+    });
+
+    // Regression test for https://github.com/facebook/jscodeshift/issues/556
+    it('ignores matching paths that start with a `../` or `./` prefix', function() {
+      expect(
+        ignores.shouldIgnore('../company.reactapp/src/node_modules/foo.js')
+      ).toBe(true);
+      expect(ignores.shouldIgnore('./src/node_modules/foo.js')).toBe(true);
+      expect(ignores.shouldIgnore('../node_modules/foo.js')).toBe(true);
+      expect(ignores.shouldIgnore('../../a/b/node_modules/x.js')).toBe(true);
+    });
+
+    it('does not ignore non-matching paths with a `../` prefix', function() {
+      expect(ignores.shouldIgnore('../src/app.js')).toBe(false);
+      expect(ignores.shouldIgnore('../src/components/Button.js')).toBe(false);
+    });
+  });
+
+  describe('with a bare directory-name pattern', function() {
+    beforeEach(function() {
+      ignores.add('node_modules');
+    });
+
+    it('ignores the directory regardless of a leading `../` prefix', function() {
+      expect(ignores.shouldIgnore('src/node_modules')).toBe(true);
+      expect(
+        ignores.shouldIgnore('../company.reactapp/src/node_modules')
+      ).toBe(true);
+      expect(ignores.shouldIgnore('../src/lib')).toBe(false);
+    });
+  });
+
+  it('accepts an array of patterns', function() {
+    ignores.add(['**/node_modules/**', '**/dist/**']);
+    expect(ignores.shouldIgnore('../src/node_modules/foo.js')).toBe(true);
+    expect(ignores.shouldIgnore('../src/dist/bundle.js')).toBe(true);
+    expect(ignores.shouldIgnore('../src/index.js')).toBe(false);
+  });
+});

--- a/src/ignoreFiles.js
+++ b/src/ignoreFiles.js
@@ -59,8 +59,23 @@ function addIgnoreFromFile(input) {
 }
 
 function shouldIgnore(path) {
-  const matched = matchers.length ? picomatch.isMatch(path, matchers, { dot:true }) : false;
-  return matched;
+  if (!matchers.length) {
+    return false;
+  }
+  // Files discovered from a relative source path (e.g. `../src` or `./src`)
+  // are enumerated with a leading `../` or `./` traversal prefix. picomatch's
+  // `**` wildcard does not match across such a leading traversal segment, so
+  // ignore patterns like `**/node_modules/**` silently fail to match those
+  // paths even though they match the equivalent absolute or plain relative
+  // paths. Match against the path with any leading traversal prefix stripped
+  // so ignore behavior is consistent regardless of how the source path was
+  // specified. See https://github.com/facebook/jscodeshift/issues/556
+  const normalizedPath = path.replace(/^(?:\.\.?[/\\])+/, '');
+  return (
+    picomatch.isMatch(path, matchers, { dot: true }) ||
+    (normalizedPath !== path &&
+      picomatch.isMatch(normalizedPath, matchers, { dot: true }))
+  );
 }
 
 exports.add = addIgnoreFromInput;


### PR DESCRIPTION
## Summary

Fixes #556.

`--ignore-pattern` (and every other ignore source that funnels through `shouldIgnore`) silently fails to match files when the source path is **relative and starts with `../`**. For example:

```sh
jscodeshift -t transform.ts ../app/src --ignore-pattern '**/node_modules/**'
```

matches nothing, so files under `node_modules` are transformed anyway, while the exact same invocation with an **absolute** source path (or a relative path without a leading `../`) ignores them correctly. Several users independently reported losing time to this on #556.

## Root cause

The directory walker in `Runner.js` builds candidate paths with `path.join(dir, file)`. When the source argument is `../app/src`, `path.join` preserves the leading `../`, so `shouldIgnore` receives paths like `../app/src/node_modules/foo.js`.

`shouldIgnore` matches these with picomatch, but picomatch's `**` wildcard does **not** match across a leading `../` (or `./`) traversal segment:

```js
const picomatch = require('picomatch');
picomatch.isMatch('src/node_modules/foo.js',        '**/node_modules/**', { dot: true }); // true
picomatch.isMatch('/abs/src/node_modules/foo.js',   '**/node_modules/**', { dot: true }); // true
picomatch.isMatch('../app/src/node_modules/foo.js', '**/node_modules/**', { dot: true }); // false  <-- the bug
```

## Fix

`shouldIgnore` now also tests the path with any leading `../`/`./` traversal prefix stripped, so a relative source path behaves the same as an absolute one. The original path is still matched first, so this is strictly additive — no path that was previously ignored stops being ignored (e.g. a literal `../secret.js` pattern still matches).

## Test plan

Added `src/__tests__/ignoreFiles-test.js` (the module had no direct coverage before). The new cases fail on `main` and pass with this change:

- glob and bare-directory patterns ignore matching `../`/`./`-prefixed paths
- absolute and plain-relative matching is unchanged
- non-matching `../` paths are still not ignored

```
Test Suites: 19 passed, 19 total
Tests:       1 skipped, 214 passed, 215 total
```

A `patch` changeset is included.
