### PR TITLE
Propagate testOptions through snapshot/inline test helpers (fixes #581)

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,9 @@ const transformOptions = {};
 defineInlineTest(transform, transformOptions, 'input', 'expected output', 'test name (optional)');
 ```
 
+An optional `testOptions` object can be passed as the last argument to select the
+parser used to run the transform, e.g. `defineInlineTest(transform, transformOptions, 'input', 'expected output', 'test name', { parser: 'tsx' })`.
+
 #### `defineSnapshotTest`
 
 Similar to `defineInlineTest` but instead of requiring an output value, it uses Jest's `toMatchSnapshot()`
@@ -521,6 +524,8 @@ const transform = require('../myTransform');
 const transformOptions = {};
 defineSnapshotTest(transform, transformOptions, 'input', 'test name (optional)');
 ```
+
+Like `defineInlineTest`, an optional `testOptions` object (e.g. `{ parser: 'tsx' }`) can be passed as the last argument to select the parser.
 
 For more information on snapshots, check out [Jest's docs](https://jestjs.io/docs/en/snapshot-testing)
 
@@ -534,6 +539,8 @@ const transform = require('../myTransform');
 const transformOptions = {};
 defineSnapshotTestFromFixture(__dirname, transform, transformOptions, 'FirstFixture', 'test name (optional)');
 ```
+
+An optional `testOptions` object (e.g. `{ parser: 'tsx' }`) can be passed as the last argument. Its `parser` is used both to resolve the fixture's file extension (`.input.tsx`) and to run the transform.
 
 #### `applyTransform`
 

--- a/src/__testfixtures__/test-tsx-transform.input.tsx
+++ b/src/__testfixtures__/test-tsx-transform.input.tsx
@@ -1,0 +1,2 @@
+enum Direction { Up, Down }
+export const sum = (a: number, b: number): number => a + b;

--- a/src/__testfixtures__/test-tsx-transform.js
+++ b/src/__testfixtures__/test-tsx-transform.js
@@ -1,0 +1,7 @@
+const tsxTestTransform = (fileInfo, api, options) => {
+  return api.jscodeshift(fileInfo.source)
+    .findVariableDeclarators('sum')
+    .renameTo('addition')
+    .toSource();
+}
+module.exports = tsxTestTransform;

--- a/src/__testfixtures__/test-tsx-transform.output.tsx
+++ b/src/__testfixtures__/test-tsx-transform.output.tsx
@@ -1,0 +1,2 @@
+enum Direction { Up, Down }
+export const addition = (a: number, b: number): number => a + b;

--- a/src/__tests__/__snapshots__/testUtils-test.js.snap
+++ b/src/__tests__/__snapshots__/testUtils-test.js.snap
@@ -11,3 +11,18 @@ exports[`testUtils synchronous should run snapshot test 1`] = `"export const add
 exports[`testUtils synchronous should run sync defineSnapshotTest 1`] = `"export const addition = (a, b) => a + b;"`;
 
 exports[`testUtils synchronous should run sync defineSnapshotTestFromFixture 1`] = `"export const addition = (a, b) => a + b;"`;
+
+exports[`testUtils testOptions propagation defineSnapshotTest forwards testOptions.parser 1`] = `
+"enum Direction { Up, Down }
+export const addition = (a: number, b: number): number => a + b;"
+`;
+
+exports[`testUtils testOptions propagation defineSnapshotTestFromFixture forwards testOptions.parser 1`] = `
+"enum Direction { Up, Down }
+export const addition = (a: number, b: number): number => a + b;"
+`;
+
+exports[`testUtils testOptions propagation runSnapshotTest forwards testOptions.parser 1`] = `
+"enum Direction { Up, Down }
+export const addition = (a: number, b: number): number => a + b;"
+`;

--- a/src/__tests__/testUtils-test.js
+++ b/src/__tests__/testUtils-test.js
@@ -11,6 +11,7 @@ const fs = require('fs');
 const path = require('path');
 const testSyncTransform = require('../__testfixtures__/test-sync-transform');
 const testAsyncTransform = require('../__testfixtures__/test-async-transform');
+const testTsxTransform = require('../__testfixtures__/test-tsx-transform');
 
 const testUtils = require('../testUtils');
 
@@ -138,6 +139,63 @@ describe('testUtils', () => {
       null,
       'test-async-transform',
       'should run async defineSnapshotTestFromFixture'
+    );
+  });
+
+  // The fixtures below are written in TypeScript and only parse with the `tsx`
+  // parser, which is selected exclusively via `testOptions.parser`. If a helper
+  // fails to forward `testOptions` to `applyTransform`, the transform runs with
+  // the default parser and throws on the `enum` declaration. See #581.
+  describe('testOptions propagation', () => {
+    const tsxInput =
+      'enum Direction { Up, Down }\nexport const sum = (a: number, b: number): number => a + b;';
+    const tsxExpectedOutput =
+      'enum Direction { Up, Down }\nexport const addition = (a: number, b: number): number => a + b;';
+    const tsxOptions = { parser: 'tsx' };
+
+    it('runSnapshotTest forwards testOptions.parser', () => {
+      testUtils.runSnapshotTest(
+        testTsxTransform,
+        null,
+        { source: tsxInput },
+        tsxOptions
+      );
+    });
+
+    it('runInlineTest forwards testOptions.parser', () => {
+      testUtils.runInlineTest(
+        testTsxTransform,
+        null,
+        { source: tsxInput },
+        tsxExpectedOutput,
+        tsxOptions
+      );
+    });
+
+    testUtils.defineInlineTest(
+      testTsxTransform,
+      null,
+      tsxInput,
+      tsxExpectedOutput,
+      'defineInlineTest forwards testOptions.parser',
+      tsxOptions
+    );
+
+    testUtils.defineSnapshotTest(
+      testTsxTransform,
+      null,
+      tsxInput,
+      'defineSnapshotTest forwards testOptions.parser',
+      tsxOptions
+    );
+
+    testUtils.defineSnapshotTestFromFixture(
+      __dirname,
+      testTsxTransform,
+      null,
+      'test-tsx-transform',
+      'defineSnapshotTestFromFixture forwards testOptions.parser',
+      tsxOptions
     );
   });
 });

--- a/src/testUtils.js
+++ b/src/testUtils.js
@@ -42,8 +42,8 @@ function applyTransform(module, options, input, testOptions = {}) {
 }
 exports.applyTransform = applyTransform;
 
-function runSnapshotTest(module, options, input) {
-  const output = applyTransform(module, options, input);
+function runSnapshotTest(module, options, input, testOptions) {
+  const output = applyTransform(module, options, input, testOptions);
   if (output instanceof Promise) {
     return output.then(output => {
       expect(output).toMatchSnapshot();
@@ -139,21 +139,21 @@ function defineTest(dirName, transformName, options, testFilePrefix, testOptions
 }
 exports.defineTest = defineTest;
 
-function defineInlineTest(module, options, input, expectedOutput, testName) {
+function defineInlineTest(module, options, input, expectedOutput, testName, testOptions) {
   it(testName || 'transforms correctly', () => {
     const testResult = runInlineTest(module, options, {
       source: input
-    }, expectedOutput);
+    }, expectedOutput, testOptions);
     return testResult instanceof Promise ? testResult : undefined;
   });
 }
 exports.defineInlineTest = defineInlineTest;
 
-function defineSnapshotTest(module, options, input, testName) {
+function defineSnapshotTest(module, options, input, testName, testOptions) {
   it(testName || 'transforms correctly', () => {
     const testResult = runSnapshotTest(module, options, {
       source: input
-    });
+    }, testOptions);
     return testResult instanceof Promise ? testResult : undefined;
   });
 }
@@ -167,7 +167,7 @@ function defineSnapshotTestFromFixture(dirName, module, options, testFilePrefix,
   const fixtureDir = path.join(dirName, '..', '__testfixtures__');
   const inputPath = path.join(fixtureDir, testFilePrefix + `.input.${extension}`);
   const source = fs.readFileSync(inputPath, 'utf8');
-  const testResult = defineSnapshotTest(module, options, source, testName)
+  const testResult = defineSnapshotTest(module, options, source, testName, testOptions)
   return testResult instanceof Promise ? testResult : undefined;
 }
 exports.defineSnapshotTestFromFixture = defineSnapshotTestFromFixture;


### PR DESCRIPTION
## Problem

`applyTransform` selects the transform's parser from `testOptions.parser`, but several public `testUtils` helpers never forward `testOptions`, so the option is silently ignored (issue #581):

- `runSnapshotTest` and `defineSnapshotTest` drop `testOptions` entirely.
- `defineInlineTest` does not accept it.
- `defineSnapshotTestFromFixture` is self-inconsistent: it *accepts* `testOptions` and uses `testOptions.parser` to pick the fixture file extension (e.g. `foo.input.tsx`), but then runs the transform with the **default** parser. A TypeScript fixture is therefore read as `.tsx` yet parsed with babel, throwing on TS-only syntax.

Only `runInlineTest`/`runTest` currently honor `testOptions.parser`. As noted in #581, the documented work-around (exporting `parser` from the transform module) forces a single parser per module and doesn't compose.

## Fix

Thread `testOptions` through the affected helpers as a **trailing optional argument**, matching the existing `runInlineTest`/`runTest` signatures:

- `runSnapshotTest(module, options, input, testOptions)`
- `defineInlineTest(module, options, input, expectedOutput, testName, testOptions)`
- `defineSnapshotTest(module, options, input, testName, testOptions)`
- `defineSnapshotTestFromFixture(...)` now forwards its already-accepted `testOptions` to `defineSnapshotTest`.

All changes are backward compatible (new optional parameters only; downstream defaults to `{}`).

The README is updated to document the `testOptions` argument for these helpers.

## Verification

Added a `testOptions propagation` describe block plus a `test-tsx-transform` fixture whose input contains an `enum` (accepted only by the `tsx`/`ts` parsers). Each helper is exercised with `{ parser: 'tsx' }`.

- Against `main`, 4 of the 5 new cases fail with `Unexpected reserved word 'enum'` (only the already-correct `runInlineTest` passes), demonstrating the bug.
- With the fix, all pass.

```
$ npx jest src/__tests__/testUtils-test.js --ci
Tests:       21 passed, 21 total
Snapshots:   9 passed, 9 total

$ npx jest   # full suite
Test Suites: 18 passed, 18 total
Tests:       1 skipped, 213 passed, 214 total
```

Fixes #581